### PR TITLE
Support UTF-8 (or non-local) encoding for PGF-files.

### DIFF
--- a/app/configeditorwidget.cpp
+++ b/app/configeditorwidget.cpp
@@ -35,44 +35,43 @@ ConfigEditorWidget::ConfigEditorWidget(QWidget *parent)
 	ui.setupUi(this);
 
 	connect(ui.generalFontButton, SIGNAL(clicked()), this, SLOT(selectFont()));
- 
- 
-     // ** Encoding
-     initializeEncoding();
+
+	// ** Encoding
+	initializeEncoding();
 }
  
- void ConfigEditorWidget::initializeEncoding()
- {
-     /// Local codec
-     QTextCodec* localCodec = QTextCodec::codecForLocale();
-     QString localCodecName;
-     if (localCodec->aliases().empty())
-         localCodecName = codecNameToString( localCodec);
-     else
-         localCodecName = codecNameToString( localCodec->aliases()[1]);
+void ConfigEditorWidget::initializeEncoding()
+{
+	/// Local codec
+	QTextCodec* localCodec = QTextCodec::codecForLocale();
+	QString localCodecName;
+	if (localCodec->aliases().empty())
+		localCodecName = codecNameToString( localCodec);
+	else
+		localCodecName = codecNameToString( localCodec->aliases()[1]);
  
-     ui.encodingComboBox->addItem(tr("System local - %1", "Encoding").arg(localCodecName), QString::fromAscii("System"));
-     ui.encodingComboBox->addItem(tr("UTF-8", "Encoding"), QString::fromAscii("UTF-8 BOM"));
-     ui.encodingComboBox->addItem(tr("UTF-8 without BOM", "Encoding"), QString::fromAscii("UTF-8"));
-     ui.encodingComboBox->addItem(tr("(Advanced)", "Encoding"), QString());
-     ui.encodingComboBox->setCurrentIndex(ui.encodingComboBox->count()-1);
- 
- 
- 
-     QComboBox* cb (ui.defaultEncodingComboBox);
-     cb->addItem(tr("(Local codec - %1)", "Encoding").arg(localCodecName), QVariant()
-                 );
-     fillCodecComboBox(cb);
+	ui.encodingComboBox->addItem(tr("System local - %1", "Encoding").arg(localCodecName), QString::fromAscii("System"));
+	ui.encodingComboBox->addItem(tr("UTF-8", "Encoding"), QString::fromAscii("UTF-8 BOM"));
+	ui.encodingComboBox->addItem(tr("UTF-8 without BOM", "Encoding"), QString::fromAscii("UTF-8"));
+	ui.encodingComboBox->addItem(tr("(Advanced)", "Encoding"), QString());
+	ui.encodingComboBox->setCurrentIndex(ui.encodingComboBox->count()-1);
  
  
-     cb = ui.readEncodingComboBox;
-     cb->addItem(tr("(Local or unicode)", "Encoding"),  QVariant());
-     fillCodecComboBox(cb);
  
-     cb = ui.writeEncodingComboBox;
-     cb->addItem(tr("(Same)", "Encoding"),  QVariant());
-     fillCodecComboBox(cb);
- }
+	QComboBox* cb (ui.defaultEncodingComboBox);
+	cb->addItem(tr("(Local codec - %1)", "Encoding").arg(localCodecName), QVariant()
+		);
+	fillCodecComboBox(cb);
+ 
+ 
+	cb = ui.readEncodingComboBox;
+	cb->addItem(tr("(Local or unicode)", "Encoding"),  QVariant());
+	fillCodecComboBox(cb);
+ 
+	cb = ui.writeEncodingComboBox;
+	cb->addItem(tr("(Same)", "Encoding"),  QVariant());
+	fillCodecComboBox(cb);
+}
  
 
 QVariant ConfigEditorWidget::defaultSetting(const QString &key)
@@ -125,13 +124,13 @@ void ConfigEditorWidget::readSettings(const QString &settingsGroup)
 	ui.useCompletionCheck->setChecked(settings.value(QLatin1String("UseCompletion"), defaultSetting(QLatin1String("UseCompletion"))).toBool());
 	
 	// encoding
-         settings.beginGroup(QLatin1String("encoding"));
-         selectEncoding(ui.defaultEncodingComboBox, settings.value(QLatin1String("default")));
-         selectEncoding(ui.readEncodingComboBox, settings.value(QLatin1String("decoder")));
-         selectEncoding(ui.writeEncodingComboBox, settings.value(QLatin1String("encoder")));
-         ui.bomCheckBox->setChecked(settings.value(QLatin1String("bom"), true).toBool());
-         selectEncoding(ui.encodingComboBox, settings.value(QLatin1String("preset"), QLatin1String("System")));
-         settings.endGroup();
+	settings.beginGroup(QLatin1String("encoding"));
+		selectEncoding(ui.defaultEncodingComboBox, settings.value(QLatin1String("default")));
+		selectEncoding(ui.readEncodingComboBox, settings.value(QLatin1String("decoder")));
+		selectEncoding(ui.writeEncodingComboBox, settings.value(QLatin1String("encoder")));
+		ui.bomCheckBox->setChecked(settings.value(QLatin1String("bom"), true).toBool());
+		selectEncoding(ui.encodingComboBox, settings.value(QLatin1String("preset"), QLatin1String("System")));
+	settings.endGroup();
 	
 	settings.endGroup();
 }
@@ -152,16 +151,16 @@ void ConfigEditorWidget::writeSettings(const QString &settingsGroup)
 	settings.setValue(QLatin1String("ColorHighlightCurrentLine"), ui.highlightCurrentLineColorButton->color());
 	settings.setValue(QLatin1String("UseCompletion"), ui.useCompletionCheck->isChecked());
 	
-    settings.beginGroup(QLatin1String("encoding"));
-         settings.setValue(QLatin1String("default"),
-                     ui.defaultEncodingComboBox->itemData(ui.defaultEncodingComboBox->currentIndex()));
-         settings.setValue(QLatin1String("encoder"),
-                     ui.writeEncodingComboBox->itemData(ui.writeEncodingComboBox->currentIndex()));
-         settings.setValue(QLatin1String("decoder"),
-                     ui.readEncodingComboBox->itemData(ui.readEncodingComboBox->currentIndex()));
-         settings.setValue(QLatin1String("bom"), ui.bomCheckBox->isChecked());
-         settings.setValue(QLatin1String("preset"),
-                     ui.encodingComboBox->itemData(ui.encodingComboBox->currentIndex()));
+	settings.beginGroup(QLatin1String("encoding"));
+		settings.setValue(QLatin1String("default"),
+			ui.defaultEncodingComboBox->itemData(ui.defaultEncodingComboBox->currentIndex()));
+		settings.setValue(QLatin1String("encoder"),
+			ui.writeEncodingComboBox->itemData(ui.writeEncodingComboBox->currentIndex()));
+		settings.setValue(QLatin1String("decoder"),
+			ui.readEncodingComboBox->itemData(ui.readEncodingComboBox->currentIndex()));
+		settings.setValue(QLatin1String("bom"), ui.bomCheckBox->isChecked());
+		settings.setValue(QLatin1String("preset"),
+			ui.encodingComboBox->itemData(ui.encodingComboBox->currentIndex()));
 	settings.endGroup();
 	settings.endGroup();
 }
@@ -175,91 +174,91 @@ void ConfigEditorWidget::selectFont()
 		m_generalFont = newFont;
 		ui.generalFontEdit->setText(m_generalFont.family() + QLatin1Char(' ') + QString::number(m_generalFont.pointSize()));
 		ui.generalFontEdit->setFont(m_generalFont);
-    }
+	}
 }
 
 
 class ComboItem
 {
 public:
-    ComboItem() {}
-    ComboItem(const QString &text, const QVariant &data):
-        text(text), data(data)
-    {}
-    QString text;
-    QVariant data;
-    bool operator <(const ComboItem &other) const {return QString::compare(this->text,  other.text, Qt::CaseInsensitive) < 0;}
+	ComboItem() {}
+	ComboItem(const QString &text, const QVariant &data):
+		text(text), data(data)
+	{}
+	QString text;
+	QVariant data;
+	bool operator <(const ComboItem &other) const {return QString::compare(this->text,  other.text, Qt::CaseInsensitive) < 0;}
 };
 void ConfigEditorWidget::fillCodecComboBox(QComboBox *cb)
 {
-    const QList<QByteArray>  ca (QTextCodec::availableCodecs());
-    QVector<ComboItem> ciList; ciList.reserve(ca.length());
-    Q_FOREACH(const QByteArray &ba , ca)
-        ciList.append(ComboItem(codecNameToString(ba), ba));
-    qSort(ciList);
-    Q_FOREACH (const ComboItem& ci, ciList) {
-        cb->addItem(ci.text, ci.data);
-    }
+	const QList<QByteArray>  ca (QTextCodec::availableCodecs());
+	QVector<ComboItem> ciList; ciList.reserve(ca.length());
+	Q_FOREACH(const QByteArray &ba , ca)
+		ciList.append(ComboItem(codecNameToString(ba), ba));
+	qSort(ciList);
+	Q_FOREACH (const ComboItem& ci, ciList) {
+		cb->addItem(ci.text, ci.data);
+	}
 }
 void ConfigEditorWidget::selectEncoding(QComboBox *cb, const QVariant &codecName)
 {
-    for(int i=0; i<cb->count(); ++i) {
-        if(cb->itemData(i) == codecName)
-        {
-            cb->setCurrentIndex(i);
-            return ;
-        }
-    }
+	for(int i=0; i<cb->count(); ++i) {
+		if(cb->itemData(i) == codecName)
+		{
+			cb->setCurrentIndex(i);
+			return ;
+		}
+	}
 }
 
 
 
 void ConfigEditorWidget::on_encodingComboBox_currentIndexChanged(int index)
 {
-    bool b = (index == -1);
-    //Q_ASSERT(b);
-    if(Q_LIKELY( ~b) ) // true when the widget is initialized...
-    {
-        QString key=ui.encodingComboBox->itemData(index).toString();
-        if (key.isEmpty())
-        {
-            b = true;
-        }
-        else
-        {
-            QVariant de, re, we;
-            bool bom ;
-            if (key.compare(QString::fromAscii("UTF-8+BOM"))==0)
-            {
-                de = QString::fromAscii("UTF-8");
-                we = de;
-                bom = true;
-            }
-            else if (key.compare(QString::fromAscii("UTF-8"))==0)
-            {
-                de = QString::fromAscii("UTF-8");
-                we = de;
-                bom = false;
-            }
-            else // if (key.compare(QString::fromAscii("System"))==0)
-            {
-                bom = true;
-            }
+	bool b = (index == -1);
+	//Q_ASSERT(b);
+	if(Q_LIKELY( ~b) ) // true when the widget is initialized...
+	{
+		QString key=ui.encodingComboBox->itemData(index).toString();
+		if (key.isEmpty())
+		{
+			b = true;
+		}
+		else
+		{
+			QVariant de, re, we;
+			bool bom ;
+			if (key.compare(QString::fromAscii("UTF-8+BOM"))==0)
+			{
+				de = QString::fromAscii("UTF-8");
+				we = de;
+				bom = true;
+			}
+			else if (key.compare(QString::fromAscii("UTF-8"))==0)
+			{
+				de = QString::fromAscii("UTF-8");
+				we = de;
+				bom = false;
+			}
+			else // if (key.compare(QString::fromAscii("System"))==0)
+			{
+				bom = true;
+			}
 
-            selectEncoding(ui.defaultEncodingComboBox,de);
-            selectEncoding(ui.readEncodingComboBox,re);
-            selectEncoding(ui.writeEncodingComboBox,we);
-            ui.bomCheckBox->setChecked(bom);
-        }
-    }
-    ui.encodingAdvWidget->setVisible(b);
+			selectEncoding(ui.defaultEncodingComboBox,de);
+			selectEncoding(ui.readEncodingComboBox,re);
+			selectEncoding(ui.writeEncodingComboBox,we);
+			ui.bomCheckBox->setChecked(bom);
+		}
+	}
+	ui.encodingAdvWidget->setVisible(b);
 
 
 }
 
 QString ConfigEditorWidget::codecNameToString(const QByteArray& codecName)
 {
-    return QString::fromAscii(codecName.constData(), codecName.length());
+	return QString::fromAscii(codecName.constData(), codecName.length());
 }
 
 QString ConfigEditorWidget::codecNameToString(QTextCodec *codec){return codecNameToString(codec->name());}

--- a/app/configeditorwidget.cpp
+++ b/app/configeditorwidget.cpp
@@ -2,6 +2,8 @@
  *   Copyright (C) 2008, 2009, 2012, 2013 by Glad Deschrijver              *
  *     <glad.deschrijver@gmail.com>                                        *
  *   Copyright (C) 2013 by João Carreira <jfmcarreira@gmail.com>           *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/app/configeditorwidget.h
+++ b/app/configeditorwidget.h
@@ -36,22 +36,22 @@ public:
 	void readSettings(const QString &settingsGroup);
 	void writeSettings(const QString &settingsGroup);
 
-    void initializeEncoding();
+	void initializeEncoding();
 protected:
 	Ui::ConfigEditorWidget ui;
 
 private Q_SLOTS:
 	void selectFont();
 
-    void on_encodingComboBox_currentIndexChanged(int index);
+	void on_encodingComboBox_currentIndexChanged(int index);
 
 private:
 	QFont m_generalFont;
 
-    static QString codecNameToString(const QByteArray &codecName);
-    static QString codecNameToString(QTextCodec *codec);
-    static void fillCodecComboBox(QComboBox *cb);
-    static void selectEncoding(QComboBox *cb, const QVariant& codecName);
+	static QString codecNameToString(const QByteArray &codecName);
+	static QString codecNameToString(QTextCodec *codec);
+	static void fillCodecComboBox(QComboBox *cb);
+	static void selectEncoding(QComboBox *cb, const QVariant& codecName);
  };
 
 #endif

--- a/app/configeditorwidget.h
+++ b/app/configeditorwidget.h
@@ -21,6 +21,9 @@
 
 #include "ui_configeditorwidget.h"
 
+class QTextCodec;
+class QComboBox;
+
 class ConfigEditorWidget : public QWidget
 {
 	Q_OBJECT
@@ -33,14 +36,22 @@ public:
 	void readSettings(const QString &settingsGroup);
 	void writeSettings(const QString &settingsGroup);
 
+    void initializeEncoding();
 protected:
 	Ui::ConfigEditorWidget ui;
 
 private Q_SLOTS:
 	void selectFont();
 
+    void on_encodingComboBox_currentIndexChanged(int index);
+
 private:
 	QFont m_generalFont;
-};
+
+    static QString codecNameToString(const QByteArray &codecName);
+    static QString codecNameToString(QTextCodec *codec);
+    static void fillCodecComboBox(QComboBox *cb);
+    static void selectEncoding(QComboBox *cb, const QVariant& codecName);
+ };
 
 #endif

--- a/app/configeditorwidget.h
+++ b/app/configeditorwidget.h
@@ -1,7 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008, 2009, 2013, 2014 by Glad Deschrijver              *
  *     <glad.deschrijver@gmail.com>                                        *
- *                                                                         *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *                                                                      *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *

--- a/app/configeditorwidget.ui
+++ b/app/configeditorwidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>ConfigEditorWidget</class>
  <widget class="QWidget" name="ConfigEditorWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>332</width>
+    <height>479</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>Configure Editor</string>
   </property>
@@ -245,6 +253,104 @@
         <property name="text">
          <string>Use command &amp;completion</string>
         </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="encodingGoupBox">
+     <property name="title">
+      <string>Encoding</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QComboBox" name="encodingComboBox"/>
+      </item>
+      <item>
+       <widget class="QWidget" name="encodingAdvWidget" native="true">
+        <layout class="QFormLayout" name="formLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label">
+           <property name="toolTip">
+            <string>Defaut encoding for new documents</string>
+           </property>
+           <property name="text">
+            <string>Defaut encoding</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="defaultEncodingComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="toolTip">
+            <string>Encoding for reading text files.
+Warning: if a BOM was detected, the decoder automatically switch to UTF-8 or UTF-16.</string>
+           </property>
+           <property name="text">
+            <string>Decoder</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QComboBox" name="readEncodingComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="toolTip">
+            <string>Encoding for saving text files</string>
+           </property>
+           <property name="text">
+            <string>Encoder</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QComboBox" name="writeEncodingComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <widget class="QCheckBox" name="bomCheckBox">
+           <property name="text">
+            <string>Add BOM to documents</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -843,14 +843,14 @@ void MainWindow::applySettings()
 	settings.beginGroup(QLatin1String("Editor"));
 	m_useCompletion = settings.value(QLatin1String("UseCompletion"), true).toBool();
 	updateCompleter();
-    settings.beginGroup(QLatin1String("encoding"));
-        QVariant qv = settings.value(QLatin1String("default"));
-        setCurrentEncoding( qv.isNull() ? QTextCodec::codecForLocale() : QTextCodec::codecForName(qv.toByteArray())) ;
-        qv = settings.value(QLatin1String("encoder"));
-        m_overrideEncoder = qv.isNull() ? NULL : QTextCodec::codecForName(qv.toByteArray()) ;
-        qv = settings.value(QLatin1String("decoder"));
-        m_overrideDecoder = qv.isNull() ? NULL : QTextCodec::codecForName(qv.toByteArray()) ;
-        m_encoderBom = settings.value(QLatin1String("bom"), true).toBool();
+	settings.beginGroup(QLatin1String("encoding"));
+		QVariant qv = settings.value(QLatin1String("default"));
+		setCurrentEncoding( qv.isNull() ? QTextCodec::codecForLocale() : QTextCodec::codecForName(qv.toByteArray())) ;
+		qv = settings.value(QLatin1String("encoder"));
+		m_overrideEncoder = qv.isNull() ? NULL : QTextCodec::codecForName(qv.toByteArray()) ;
+		qv = settings.value(QLatin1String("decoder"));
+		m_overrideDecoder = qv.isNull() ? NULL : QTextCodec::codecForName(qv.toByteArray()) ;
+		m_encoderBom = settings.value(QLatin1String("bom"), true).toBool();
 	settings.endGroup();
 
 	m_tikzHighlighter->applySettings();
@@ -965,8 +965,8 @@ void MainWindow::loadUrl(const Url &url)
 	           m_tikzPreviewController, SLOT(regeneratePreviewAfterDelay()));
 	QTextStream in(file.file());
 	QApplication::setOverrideCursor(Qt::WaitCursor);
-    this->configureStreamDecoding(in);
-    m_tikzEditorView->editor()->setPlainText(in.readAll());
+	this->configureStreamDecoding(in);
+	m_tikzEditorView->editor()->setPlainText(in.readAll());
 	setCurrentEncoding(in.codec());
 	QApplication::restoreOverrideCursor();
 //qCritical() << "loadUrl" << t.msecsTo(QTime::currentTime());
@@ -1002,7 +1002,7 @@ bool MainWindow::saveUrl(const Url &url)
 	QTextStream out(file.file());
 	QApplication::setOverrideCursor(Qt::WaitCursor);
 
-    this->configureStreamEncoding(out);
+	this->configureStreamEncoding(out);
 	out << m_tikzEditorView->editor()->toPlainText();
 	out.flush();
 	QApplication::restoreOverrideCursor();
@@ -1026,7 +1026,7 @@ bool MainWindow::saveUrl(const Url &url)
 
 void MainWindow::setCurrentEncoding(QTextCodec *codec, bool isUserRequest)
 {
-    m_currentEncoding = codec;
+	m_currentEncoding = codec;
    // TODO: implement user warning and suggestion to reload the file.
 }
 
@@ -1051,40 +1051,42 @@ QString MainWindow::strippedName(const Url &url) const
 	return (fileName.isEmpty()) ? QLatin1String("untitled.txt") : fileName;
 }
 
-QTextCodec *MainWindow::getEncoder() const {
-    return this->m_overrideEncoder ? this->m_overrideEncoder : this->m_currentEncoding;  }
+QTextCodec *MainWindow::getEncoder() const
+{
+	return this->m_overrideEncoder ? this->m_overrideEncoder : this->m_currentEncoding;
+}
 
 void MainWindow::configureStreamEncoding(QTextStream& textStream)
 {
-    QTextCodec* encoder = this->getEncoder();
-    if(Q_LIKELY(encoder)) // should be true
-        textStream.setCodec(encoder);
-    else
-        qWarning("The encoder variable should not be null.");
+	QTextCodec* encoder = this->getEncoder();
+	if(Q_LIKELY(encoder)) // should be true
+		textStream.setCodec(encoder);
+	else
+		qWarning("The encoder variable should not be null.");
 
-    textStream.setGenerateByteOrderMark(this->m_encoderBom);
+	textStream.setGenerateByteOrderMark(this->m_encoderBom);
 
 }
 
 void MainWindow::configureStreamDecoding(QTextStream &textStream)
 {
-    if(m_overrideDecoder)
-    {
-        textStream.setCodec(m_overrideDecoder);
-    }
-    textStream.setAutoDetectUnicode(true);
+	if(m_overrideDecoder)
+	{
+		textStream.setCodec(m_overrideDecoder);
+	}
+	textStream.setAutoDetectUnicode(true);
 }
 
 /***************************************************************************/
 
 void MainWindow::setLineNumber(int lineNumber)
 {
-    m_tikzEditorView->goToLine(lineNumber - 1);
+	m_tikzEditorView->goToLine(lineNumber - 1);
 }
 
 int MainWindow::lineNumber() const
 {
-    return m_tikzEditorView->lineNumber();
+	return m_tikzEditorView->lineNumber();
 }
 
 /***************************************************************************/

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -3,6 +3,8 @@
  *     <florian@hackenberger.at>                                           *
  *   Copyright (C) 2007, 2008, 2009, 2010, 2012 by Glad Deschrijver        *
  *     <glad.deschrijver@gmail.com>                                        *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -223,7 +223,7 @@ private:
     QTextCodec* m_overrideEncoder;
     /// If not null, override the decoder
     QTextCodec* m_overrideDecoder;
-    /// True if a BOM must be had to the text file
+    /// True if a BOM must be added to the PGF-file
     bool m_encoderBom;
     /// Return the current encoder (m_currentEncoding or another if encoder is overriden).
     /*virtual*/ QTextCodec* getEncoder() const;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -92,6 +92,9 @@ public:
 		return s_mainWindowList;
 	}
 
+    virtual void configureStreamEncoding(QTextStream &textStream);
+    virtual void configureStreamDecoding(QTextStream &textStream);
+
 public Q_SLOTS:
 	void loadUrl(const Url &url);
 	bool save();
@@ -130,6 +133,9 @@ private Q_SLOTS:
 	void showCursorPosition(int row, int col);
 	void showMouseCoordinates(qreal x, qreal y, int precisionX = 5, int precisionY = 5);
 	void updateCompleter();
+    /// Change the codec for the current document
+    /// @param isUserRequest set to true if the user request the changement (in this case, the application should warn the user -- not implemented yet.).
+    void setCurrentEncoding(QTextCodec* codec, bool isUserRequest = false);
 
 private:
 	void createActions();
@@ -212,6 +218,16 @@ private:
 	QPointer<ConfigDialog> m_configDialog;
 
 	Url m_currentUrl;
+	QTextCodec* m_currentEncoding;
+    /// If not null, override the encoder (rather than @ref m_currentEncoding)
+    QTextCodec* m_overrideEncoder;
+    /// If not null, override the decoder
+    QTextCodec* m_overrideDecoder;
+    /// True if a BOM must be had to the text file
+    bool m_encoderBom;
+    /// Return the current encoder (m_currentEncoding or another if encoder is overriden).
+    /*virtual*/ QTextCodec* getEncoder() const;
+
 	Url m_lastUrl;
 	QDateTime m_lastInternalModifiedDateTime;
 	bool m_isModifiedExternally;

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -3,6 +3,8 @@
  *     <florian@hackenberger.at>                                           *
  *   Copyright (C) 2007, 2008, 2009, 2010, 2012, 2014                      *
  *     by Glad Deschrijver <glad.deschrijver@gmail.com>                    *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -92,8 +92,8 @@ public:
 		return s_mainWindowList;
 	}
 
-    virtual void configureStreamEncoding(QTextStream &textStream);
-    virtual void configureStreamDecoding(QTextStream &textStream);
+	virtual void configureStreamEncoding(QTextStream &textStream);
+	virtual void configureStreamDecoding(QTextStream &textStream);
 
 public Q_SLOTS:
 	void loadUrl(const Url &url);
@@ -133,9 +133,9 @@ private Q_SLOTS:
 	void showCursorPosition(int row, int col);
 	void showMouseCoordinates(qreal x, qreal y, int precisionX = 5, int precisionY = 5);
 	void updateCompleter();
-    /// Change the codec for the current document
-    /// @param isUserRequest set to true if the user request the changement (in this case, the application should warn the user -- not implemented yet.).
-    void setCurrentEncoding(QTextCodec* codec, bool isUserRequest = false);
+	/// Change the codec for the current document
+	/// @param isUserRequest set to true if the user requested the changement (in this case, the application should warn the user -- not implemented yet.).
+	void setCurrentEncoding(QTextCodec* codec, bool isUserRequest = false);
 
 private:
 	void createActions();
@@ -219,14 +219,14 @@ private:
 
 	Url m_currentUrl;
 	QTextCodec* m_currentEncoding;
-    /// If not null, override the encoder (rather than @ref m_currentEncoding)
-    QTextCodec* m_overrideEncoder;
-    /// If not null, override the decoder
-    QTextCodec* m_overrideDecoder;
-    /// True if a BOM must be added to the PGF-file
-    bool m_encoderBom;
-    /// Return the current encoder (m_currentEncoding or another if encoder is overriden).
-    /*virtual*/ QTextCodec* getEncoder() const;
+	/// If not null, override the encoder (rather than @ref m_currentEncoding)
+	QTextCodec* m_overrideEncoder;
+	/// If not null, override the decoder
+	QTextCodec* m_overrideDecoder;
+	/// True if a BOM must be added to the PGF-file
+	bool m_encoderBom;
+	/// Return the current encoder (m_currentEncoding or another if encoder is overriden).
+	/*virtual*/ QTextCodec* getEncoder() const;
 
 	Url m_lastUrl;
 	QDateTime m_lastInternalModifiedDateTime;

--- a/common/common.pri
+++ b/common/common.pri
@@ -17,4 +17,5 @@ SOURCES += \
 	$${PWD}/tikzpreviewrenderer.cpp
 HEADERS += \
 #	$$headerFiles($$SOURCES) \
-	$${PWD}/mainwidget.h
+	$${PWD}/mainwidget.h \
+    $$PWD/textcodecprofile.h

--- a/common/mainwidget.h
+++ b/common/mainwidget.h
@@ -27,8 +27,9 @@
 #endif
 
 #include "utils/url.h"
+#include "textcodecprofile.h"
 
-class MainWidget
+class MainWidget : TextCodecProfile
 {
 public:
 	virtual ~MainWidget() {}
@@ -44,7 +45,7 @@ public:
 	virtual Url url() const
 	{
 		return Url();
-	}
+    }
 };
 
 #endif

--- a/common/textcodecprofile.h
+++ b/common/textcodecprofile.h
@@ -1,0 +1,28 @@
+#ifndef TEXTCODECPROFILE_H
+#define TEXTCODECPROFILE_H
+
+class QTextStream;
+
+class TextCodecProfile{
+public:
+    /* /// Return the QTextCodec for saving TeX files.
+    /// @return Non-null instance of QTextCodec.
+    virtual QTextCodec* getEncoder() const
+    {
+        return QTextCodec::codecForLocale();
+    }*/
+    /// Configure a QTextStream to encode a TeX file.
+    /// @arg textStream A non-null instance of QTextStream.
+    void configureStreamEncoding(QTextStream& textStream) const
+    {
+        Q_UNUSED(textStream);
+    }
+    /// Configure a QTextStream to decode a TeX file.
+    /// @arg textStream A non-null instance of QTextStream.
+    void configureStreamDecoding(QTextStream& textStream) const
+    {
+        Q_UNUSED(textStream);
+    }
+};
+
+#endif // TEXTCODECPROFILE_H

--- a/common/textcodecprofile.h
+++ b/common/textcodecprofile.h
@@ -1,3 +1,21 @@
+/***************************************************************************
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>.  *
+ ***************************************************************************/
+
 #ifndef TEXTCODECPROFILE_H
 #define TEXTCODECPROFILE_H
 

--- a/common/textcodecprofile.h
+++ b/common/textcodecprofile.h
@@ -5,24 +5,18 @@ class QTextStream;
 
 class TextCodecProfile{
 public:
-    /* /// Return the QTextCodec for saving TeX files.
-    /// @return Non-null instance of QTextCodec.
-    virtual QTextCodec* getEncoder() const
-    {
-        return QTextCodec::codecForLocale();
-    }*/
-    /// Configure a QTextStream to encode a TeX file.
-    /// @arg textStream A non-null instance of QTextStream.
-    void configureStreamEncoding(QTextStream& textStream) const
-    {
-        Q_UNUSED(textStream);
-    }
-    /// Configure a QTextStream to decode a TeX file.
-    /// @arg textStream A non-null instance of QTextStream.
-    void configureStreamDecoding(QTextStream& textStream) const
-    {
-        Q_UNUSED(textStream);
-    }
+	/// Configure a QTextStream to encode a TeX file.
+	/// @arg textStream A non-null instance of QTextStream.
+	void configureStreamEncoding(QTextStream& textStream) const
+	{
+		Q_UNUSED(textStream);
+	}
+	/// Configure a QTextStream to decode a TeX file.
+	/// @arg textStream A non-null instance of QTextStream.
+	void configureStreamDecoding(QTextStream& textStream) const
+	{
+		Q_UNUSED(textStream);
+	}
 };
 
 #endif // TEXTCODECPROFILE_H

--- a/common/tikzpreviewcontroller.cpp
+++ b/common/tikzpreviewcontroller.cpp
@@ -108,7 +108,7 @@ TikzPreviewController::~TikzPreviewController()
 /***************************************************************************/
 
 const TextCodecProfile *TikzPreviewController::textCodecProfile() const {
-    return (TextCodecProfile*) this->m_mainWidget;
+	return (TextCodecProfile*) this->m_mainWidget;
 }
 
 

--- a/common/tikzpreviewcontroller.cpp
+++ b/common/tikzpreviewcontroller.cpp
@@ -107,6 +107,13 @@ TikzPreviewController::~TikzPreviewController()
 
 /***************************************************************************/
 
+const TextCodecProfile *TikzPreviewController::textCodecProfile() const {
+    return (TextCodecProfile*) this->m_mainWidget;
+}
+
+
+/***************************************************************************/
+
 const QString TikzPreviewController::tempDir() const
 {
 	return m_tempDir->name();

--- a/common/tikzpreviewcontroller.cpp
+++ b/common/tikzpreviewcontroller.cpp
@@ -1,6 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008, 2009, 2010, 2011, 2012, 2014                      *
  *     by Glad Deschrijver <glad.deschrijver@gmail.com>                    *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/common/tikzpreviewcontroller.h
+++ b/common/tikzpreviewcontroller.h
@@ -47,7 +47,7 @@ public:
 	explicit TikzPreviewController(MainWidget *mainWidget);
 	~TikzPreviewController();
 
-    const TextCodecProfile* textCodecProfile() const;
+	const TextCodecProfile* textCodecProfile() const;
 	const QString tempDir() const;
 	const QString tempDirLocation() const;
 	TemplateWidget *templateWidget() const;

--- a/common/tikzpreviewcontroller.h
+++ b/common/tikzpreviewcontroller.h
@@ -31,6 +31,7 @@ class QToolBar;
 
 class QPrinter;
 class QTimer;
+class TextCodecProfile;
 class MainWidget;
 class TemplateWidget;
 class TikzPreview;
@@ -46,6 +47,7 @@ public:
 	explicit TikzPreviewController(MainWidget *mainWidget);
 	~TikzPreviewController();
 
+    const TextCodecProfile* textCodecProfile() const;
 	const QString tempDir() const;
 	const QString tempDirLocation() const;
 	TemplateWidget *templateWidget() const;

--- a/common/tikzpreviewcontroller.h
+++ b/common/tikzpreviewcontroller.h
@@ -1,6 +1,8 @@
 /***************************************************************************
  *   Copyright (C) 2008, 2009, 2010, 2011, 2012, 2014                      *
  *     by Glad Deschrijver <glad.deschrijver@gmail.com>                    *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/common/tikzpreviewgenerator.cpp
+++ b/common/tikzpreviewgenerator.cpp
@@ -311,7 +311,7 @@ void TikzPreviewGenerator::createPreview()
 	// load template file if changed
 	if (m_templateChanged)
 	{
-        const QString errorString = createTempLatexFile(m_tikzFileBaseName, m_templateFileName, m_tikzReplaceText, m_parent->textCodecProfile());
+		const QString errorString = createTempLatexFile(m_tikzFileBaseName, m_templateFileName, m_tikzReplaceText, m_parent->textCodecProfile());
 		if (!errorString.isEmpty())
 		{
 			showFileWriteError(m_tikzFileBaseName + QLatin1String(".tex"), errorString);
@@ -322,7 +322,7 @@ void TikzPreviewGenerator::createPreview()
 	}
 
 	// load tikz code
-    const QString errorString = createTempTikzFile(m_tikzFileBaseName, m_tikzCode, m_parent->textCodecProfile());
+	const QString errorString = createTempTikzFile(m_tikzFileBaseName, m_tikzCode, m_parent->textCodecProfile());
 	if (!errorString.isEmpty())
 	{
 		showFileWriteError(m_tikzFileBaseName + QLatin1String(".pgf"), errorString);
@@ -452,7 +452,7 @@ static QString createTempLatexFile(const QString &tikzFileBaseName, const QStrin
 		return tikzTexFile.errorString();
 
 	QTextStream tikzStream(tikzTexFile.file());
-    codecProfile->configureStreamEncoding(tikzStream);
+	codecProfile->configureStreamEncoding(tikzStream);
 
 	QFile templateFile(templateFileName);
 #ifdef KTIKZ_USE_KDE
@@ -461,11 +461,11 @@ static QString createTempLatexFile(const QString &tikzFileBaseName, const QStrin
 #else
 	if (QFileInfo(templateFile).isFile()
 #endif
-	        && templateFile.open(QIODevice::ReadOnly | QIODevice::Text) // if user-specified template file is readable
-	        && !tikzReplaceText.isEmpty())
+			&& templateFile.open(QIODevice::ReadOnly | QIODevice::Text) // if user-specified template file is readable
+			&& !tikzReplaceText.isEmpty())
 	{
 		QTextStream templateFileStream(&templateFile);
-        codecProfile->configureStreamDecoding(templateFileStream);
+		codecProfile->configureStreamDecoding(templateFileStream);
 		while (!templateFileStream.atEnd())
 		{
 			QString templateLine = templateFileStream.readLine();
@@ -503,7 +503,7 @@ static QString createTempTikzFile(const QString &tikzFileBaseName, const QString
 		return tikzFile.errorString();
 
 	QTextStream tikzStream(tikzFile.file());
-    codecProfile->configureStreamEncoding(tikzStream);
+	codecProfile->configureStreamEncoding(tikzStream);
 
 	tikzStream << tikzCode << endl;
 	tikzStream.flush();
@@ -536,7 +536,7 @@ void TikzPreviewGenerator::removeFromLatexSearchPath(const QString &path)
 }
 
 bool TikzPreviewGenerator::runProcess(const QString &name, const QString &command,
-                                      const QStringList &arguments, const QString &workingDir)
+									  const QStringList &arguments, const QString &workingDir)
 {
 	QString shortLogText;
 	QString longLogText;

--- a/common/tikzpreviewgenerator.cpp
+++ b/common/tikzpreviewgenerator.cpp
@@ -3,6 +3,8 @@
  *     <florian@hackenberger.at>                                           *
  *   Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2014                *
  *     by Glad Deschrijver <glad.deschrijver@gmail.com>                    *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/common/tikzpreviewgenerator.h
+++ b/common/tikzpreviewgenerator.h
@@ -28,7 +28,7 @@
 
 class QPixmap;
 class QProcess;
-class QPlainTextEdit;
+class QPlainEdit;
 class QTextStream;
 
 namespace Poppler

--- a/common/tikzpreviewgenerator.h
+++ b/common/tikzpreviewgenerator.h
@@ -3,6 +3,8 @@
  *     <florian@hackenberger.at>                                           *
  *   Copyright (C) 2007, 2008, 2009, 2010, 2011, 2012, 2014                *
  *     by Glad Deschrijver <glad.deschrijver@gmail.com>                    *
+ *   Copyright (C) 2016 by G. Prudhomme                                    *
+ *     <gprud@users.noreply.github.com>                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/data/examples/utf8-demo-accents.pgf
+++ b/data/examples/utf8-demo-accents.pgf
@@ -1,0 +1,6 @@
+﻿\begin{tikzpicture}[text width=6cm, align=center]
+	\path
+		node(A){This is a node with French accents~: é è ê ë  à ç ô û ù.  }
+	node[below=of A](B){Without unicode or encoding support (and inputenc \TeX{} package), this text has to be written like this~: \'e \` e \^e \"e  \`a \c{c} \^o \^u \`u.  }
+		node[below=of B]{This should work with any language.};
+\end{tikzpicture}

--- a/data/examples/utf8-template.pgs
+++ b/data/examples/utf8-template.pgs
@@ -1,0 +1,21 @@
+\documentclass{article}
+\usepackage{mathptmx}
+\usepackage{tikz}
+\usepackage[utf8]{inputenc}
+%\usepackage{color}
+\usepackage[active,pdftex,tightpage]{preview}
+\PreviewEnvironment[]{tikzpicture}
+\PreviewEnvironment[]{pgfpicture}
+\DeclareSymbolFont{symbolsb}{OMS}{cmsy}{m}{n}
+\SetSymbolFont{symbolsb}{bold}{OMS}{cmsy}{b}{n}
+\DeclareSymbolFontAlphabet{\mathcal}{symbolsb}
+
+\usetikzlibrary{positioning}
+
+\tikzset{
+  >=stealth
+}
+
+\begin{document}
+<>
+\end{document}


### PR DESCRIPTION
Hey,

I use (a lot) TikZ and ktikz. However, I cannot use (French) accents inside my draws because documents are exported with a different encoding than the one defined in the root TeX file (through inputenc package).

So, I have made some additions inside the load/save procedures. The standard behavior is to use the local decoder, or UTF-8 if the BOM is detected. Then, the same coder is used to write the file (adding a BOM if Unicode). This should be OK for most of the users.

For specific uses, the decoder or/and encoder can be overridden. So, options have been added inside “editor” tabs.