### PR TITLE
Force qMax to use qreal template

### DIFF
--- a/app/tikzeditor.cpp
+++ b/app/tikzeditor.cpp
@@ -319,7 +319,7 @@ void TikzEditor::printWhiteSpaces(QPainter &painter)
 
 	QPen backupPen(painter.pen());
 	QPen tabulatorsPen(m_tabulatorsColor);
-	tabulatorsPen.setWidthF(qMax(qreal(0.5), spaceWidth * .1));
+	tabulatorsPen.setWidthF(qMax(qreal(0.5), qreal(spaceWidth * .1)));
 	tabulatorsPen.setCapStyle(Qt::RoundCap);
 	tabulatorsPen.setJoinStyle(Qt::RoundJoin);
 	QPen whiteSpacesPen(m_whiteSpacesColor);


### PR DESCRIPTION
armhf and armel have qreal == float while on all other archs it is a double. `qMax(qreal, double)` therefore fails on armhf and armel.

    /«PKGBUILDDIR»/app/tikzeditor.cpp:322:58: error: no matching function for call to 'qMax(qreal, double)'
        tabulatorsPen.setWidthF(qMax(qreal(0.5), spaceWidth * .1));
                                                              ^
    In file included from /usr/include/qt4/QtCore/QtGlobal:1:0,
                     from /«PKGBUILDDIR»/app/tikzeditor.h:23,
                     from /«PKGBUILDDIR»/app/tikzeditor.cpp:38:
    /usr/include/qt4/QtCore/qglobal.h:1330:34: note: candidate: template<class T> constexpr const T& qMax(const T&, const T&)
     Q_DECL_CONSTEXPR inline const T &qMax(const T &a, const T &b) { return (a < b) ? b : a; }
                                  ^~~~
    /usr/include/qt4/QtCore/qglobal.h:1330:34: note:   template argument deduction/substitution failed:
    /«PKGBUILDDIR»/app/tikzeditor.cpp:322:58: note:   deduced conflicting types for parameter 'const T' ('float' and 'double')
      tabulatorsPen.setWidthF(qMax(qreal(0.5), spaceWidth * .1));
                                                              ^
    app/CMakeFiles/ktikz.dir/build.make:625: recipe for target 'app/CMakeFiles/ktikz.dir/tikzeditor.cpp.o' failed

https://buildd.debian.org/status/fetch.php?pkg=ktikz&arch=armel&ver=0.11%7Egit20150904-1&stamp=1472992294&raw=0


Thanks to Sune Vuorela for the information.