### PR TITLE
Fix QString for no QT_NO_CAST_FROM_ASCII

### DIFF
--- a/common/tikzpreviewgenerator.cpp
+++ b/common/tikzpreviewgenerator.cpp
@@ -503,7 +503,7 @@ static QString createTempTikzFile(const QString &tikzFileBaseName, const QString
 	QFile tikzFile(tikzFileBaseName + QLatin1String(".pgf"));
 
 	if (!tikzFile.open(QFile::WriteOnly))
-		return QString("Could not open \"%1\".").arg(tikzFileBaseName);
+		return QString::fromUtf8("Could not open \"%1\".").arg(tikzFileBaseName);
 
 	QTextStream tikzStream(&tikzFile);
 	codecProfile->configureStreamEncoding(tikzStream);


### PR DESCRIPTION
When building with Qt 5.9 in Debian and the standard Qt/KDE build helpers,
QT_NO_CAST_FROM_ASCII is set, which prevents using ASCII strings directly
within the QString constructor.

The attached patch is required to build; the relevant QString constructor is otherwise private. [http://doc.qt.io/qt-5/qstring.html#converting-between-8-bit-strings-and-unicode-strings](http://doc.qt.io/qt-5/qstring.html#converting-between-8-bit-strings-and-unicode-strings)