### PR TITLE
Fix travis job after Qt5 package split

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 dist: xenial
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install build-essential cmake qtbase5-dev libpoppler-qt5-dev preview-latex-style
-script: mkdir -p buildqt && cd buildqt && qmake -qt5 ../qtikz.pro && make && cd ..
+  - sudo apt-get install build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libpoppler-qt5-dev preview-latex-style
+script: mkdir -p buildqt && cd buildqt && QT_SELECT=5 qmake ../qtikz.pro && QT_SELECT=5  make && cd ..
 # The full build script with Qt and KDE builds fails for now, see https://travis-ci.org/fhackenberger/ktikz/builds/265616161
 # script: mkdir -p buildqt && cd buildqt && qmake ../qtikz.pro && make && cd .. && git clean -f -d && mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=`kde4-config --prefix` .. && make


### PR DESCRIPTION
This is a work-in-progress branch to try to address the travis failures for the `frameworks` branch and this PR only exists so that we can get travis to run!