### PR TITLE
Enable Travis CI builds for KF5 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - MAKEFLAGS="-j 2"
+
 language: cpp
 dist: xenial
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,13 @@ env:
 
 language: cpp
 dist: xenial
+
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install build-essential cmake qtbase5-dev qttools5-dev qttools5-dev-tools libpoppler-qt5-dev preview-latex-style
-script: mkdir -p buildqt && cd buildqt && QT_SELECT=5 qmake ../qtikz.pro && QT_SELECT=5  make && cd ..
-# The full build script with Qt and KDE builds fails for now, see https://travis-ci.org/fhackenberger/ktikz/builds/265616161
-# script: mkdir -p buildqt && cd buildqt && qmake ../qtikz.pro && make && cd .. && git clean -f -d && mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=`kde4-config --prefix` .. && make
+  - sudo apt-get install -y build-essential preview-latex-style
+  - sudo apt-get install -y qtbase5-dev qttools5-dev qttools5-dev-tools libpoppler-qt5-dev
+  - sudo apt-get install -y cmake extra-cmake-modules kdoctools-dev libkf5iconthemes-dev libkf5kdelibs4support-dev libkf5parts-dev libkf5texteditor-dev libkf5xmlgui-dev libpoppler-qt5-dev libqt5sql5-sqlite pkg-config
+
+script:
+  - mkdir buildqt && cd buildqt && QT_SELECT=5 qmake ../qtikz.pro && QT_SELECT=5 make && cd ..
+  - mkdir build && cd build && cmake .. && make && cd ..

--- a/FindPoppler.cmake
+++ b/FindPoppler.cmake
@@ -1,115 +1,151 @@
-# - Try to find the poppler PDF library
-# Once done this will define
+#.rst:
+# FindPoppler
+# -----------
 #
-#  POPPLER_FOUND - system has poppler
-#  POPPLER_INCLUDE_DIR - the poppler include directory
-#  POPPLER_LIBRARY - Link this to use poppler
+# Try to find Poppler.
 #
-
-# Copyright (c) 2006-2010, Pino Toscano, <pino@kde.org>
+# This is a component-based find module, which makes use of the COMPONENTS
+# and OPTIONAL_COMPONENTS arguments to find_module.  The following components
+# are available::
 #
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#   Core  Cpp  Qt5  Qt4 Glib
+#
+# If no components are specified, this module will act as though all components
+# were passed to OPTIONAL_COMPONENTS.
+#
+# This module will define the following variables, independently of the
+# components searched for or found:
+#
+# ``Poppler_FOUND``
+#     TRUE if (the requested version of) Poppler is available
+# ``Poppler_VERSION``
+#     Found Poppler version
+# ``Poppler_TARGETS``
+#     A list of all targets imported by this module (note that there may be more
+#     than the components that were requested)
+# ``Poppler_LIBRARIES``
+#     This can be passed to target_link_libraries() instead of the imported
+#     targets
+# ``Poppler_INCLUDE_DIRS``
+#     This should be passed to target_include_directories() if the targets are
+#     not used for linking
+# ``Poppler_DEFINITIONS``
+#     This should be passed to target_compile_options() if the targets are not
+#     used for linking
+#
+# For each searched-for components, ``Poppler_<component>_FOUND`` will be set to
+# TRUE if the corresponding Poppler library was found, and FALSE otherwise.  If
+# ``Poppler_<component>_FOUND`` is TRUE, the imported target
+# ``Poppler::<component>`` will be defined.  This module will also attempt to
+# determine ``Poppler_*_VERSION`` variables for each imported target, although
+# ``Poppler_VERSION`` should normally be sufficient.
+#
+# In general we recommend using the imported targets, as they are easier to use
+# and provide more control.  Bear in mind, however, that if any target is in the
+# link interface of an exported library, it must be made available by the
+# package config file.
+#
+# Since 5.19
 
-if(POPPLER_INCLUDE_DIR AND POPPLER_LIBRARY)
+#=============================================================================
+# Copyright 2015 Alex Richardson <arichardson.kde@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+include(/usr/share/ECM/modules/ECMFindModuleHelpers.cmake)
 
-  # in cache already
-  set(POPPLER_FOUND TRUE)
+ecm_find_package_version_check(Poppler)
 
-else(POPPLER_INCLUDE_DIR AND POPPLER_LIBRARY)
+set(Poppler_known_components
+    Cpp
+    Qt4
+    Qt5
+    Glib
+)
+foreach(_comp ${Poppler_known_components})
+    string(TOLOWER "${_comp}" _lc_comp)
+    set(Poppler_${_comp}_component_deps "Core")
+    set(Poppler_${_comp}_pkg_config "poppler-${_lc_comp}")
+    set(Poppler_${_comp}_lib "poppler-${_lc_comp}")
+    set(Poppler_${_comp}_header_subdir "poppler/${_lc_comp}")
+endforeach()
+set(Poppler_known_components Core ${Poppler_known_components})
 
-set(_poppler_version_bad FALSE)
+set(Poppler_Core_component_deps "")
+set(Poppler_Core_pkg_config "poppler")
+# poppler-config.h header is only installed with --enable-xpdf-headers
+# fall back to using any header from a submodule with a path to make it work in that case too
+set(Poppler_Core_header "poppler-config.h" "cpp/poppler-version.h" "qt5/poppler-qt5.h" "qt4/poppler-qt4.h" "glib/poppler.h")
+set(Poppler_Core_header_subdir "poppler")
+set(Poppler_Core_lib "poppler")
 
-if(NOT WIN32)
-  # use pkg-config to get the directories and then use these values
-  # in the FIND_PATH() and FIND_LIBRARY() calls
-  include(FindPkgConfig)
-  pkg_check_modules(_pc_poppler poppler-qt5)
-  if(_pc_poppler_FOUND)
-    if(NOT "${_pc_poppler_VERSION}" VERSION_GREATER 0.5.3)
-      set(_poppler_version_bad TRUE)
-    endif(NOT "${_pc_poppler_VERSION}" VERSION_GREATER 0.5.3)
-  endif(_pc_poppler_FOUND)
-endif(NOT WIN32)
+set(Poppler_Cpp_header "poppler-version.h")
+set(Poppler_Qt5_header "poppler-qt5.h")
+set(Poppler_Qt4_header "poppler-qt4.h")
+set(Poppler_Glib_header "poppler.h")
 
-if(NOT _poppler_version_bad)
-  set(POPPLER_FOUND FALSE)
+ecm_find_package_parse_components(Poppler
+    RESULT_VAR Poppler_components
+    KNOWN_COMPONENTS ${Poppler_known_components}
+)
+ecm_find_package_handle_library_components(Poppler
+    COMPONENTS ${Poppler_components}
+)
 
-  find_library(POPPLER_LIBRARY poppler-qt5
-               HINTS ${_pc_poppler_LIBRARY_DIRS}
-  )
+# If pkg-config didn't provide us with version information,
+# try to extract it from poppler-version.h or poppler-config.h
+if(NOT Poppler_VERSION)
+    find_file(Poppler_VERSION_HEADER
+        NAMES "poppler-config.h" "cpp/poppler-version.h"
+        HINTS ${Poppler_INCLUDE_DIRS}
+        PATH_SUFFIXES ${Poppler_Core_header_subdir}
+    )
+    mark_as_advanced(Poppler_VERSION_HEADER)
+    if(Poppler_VERSION_HEADER)
+        file(READ ${Poppler_VERSION_HEADER} _poppler_version_header_contents)
+        string(REGEX REPLACE
+            "^.*[ \t]+POPPLER_VERSION[ \t]+\"([0-9d.]*)\".*$"
+            "\\1"
+            Poppler_VERSION
+            "${_poppler_version_header_contents}"
+        )
+        unset(_poppler_version_header_contents)
+    endif()
+endif()
 
-  find_path(POPPLER_INCLUDE_DIR poppler-qt5.h
-            HINTS ${_pc_poppler_INCLUDE_DIRS}
-            PATH_SUFFIXES poppler/qt5
-  )
-  find_path(POPPLER_INCLUDE_DIR_core qt5/poppler-qt5.h
-            HINTS ${_pc_poppler_INCLUDE_DIRS}
-            PATH_SUFFIXES poppler
-  )
+find_package_handle_standard_args(Poppler
+    FOUND_VAR
+        Poppler_FOUND
+    REQUIRED_VARS
+        Poppler_LIBRARIES
+    VERSION_VAR
+        Poppler_VERSION
+    HANDLE_COMPONENTS
+)
 
-  if(POPPLER_LIBRARY AND POPPLER_INCLUDE_DIR AND POPPLER_INCLUDE_DIR_core)
-    list(APPEND POPPLER_INCLUDE_DIR "${POPPLER_INCLUDE_DIR_core}")
-    set(POPPLER_FOUND TRUE)
-  endif(POPPLER_LIBRARY AND POPPLER_INCLUDE_DIR AND POPPLER_INCLUDE_DIR_core)
-endif(NOT _poppler_version_bad)
-
-if (POPPLER_FOUND)
-  include(CheckCXXSourceCompiles)
-
-  set(CMAKE_REQUIRED_INCLUDES ${POPPLER_INCLUDE_DIR} ${QT_INCLUDE_DIR})
-  set(CMAKE_REQUIRED_LIBRARIES ${POPPLER_LIBRARY} ${QT_QTCORE_LIBRARY} ${QT_QTGUI_LIBRARY} ${QT_QTXML_LIBRARY})
-
-check_cxx_source_compiles("
-#include <poppler-qt5.h>
-int main()
-{
-  Poppler::Document::RenderHint hint = Poppler::Document::ThinLineSolid;
-  return 0;
-}
-" HAVE_POPPLER_0_24)
-
-check_cxx_source_compiles("
-#include <poppler-qt5.h>
-int main()
-{
-  Poppler::Page *p = 0;
-  p->annotations( QSet<Poppler::Annotation::SubType>() << Poppler::Annotation::ASound );
-  return 0;
-}
-" HAVE_POPPLER_0_28)
-
-check_cxx_source_compiles("
-#include <poppler-qt5.h>
-int main()
-{
-  Poppler::Page *p = 0;
-  p->annotations( QSet<Poppler::Annotation::SubType>() << Poppler::Annotation::ARichMedia );
-  return 0;
-}
-" HAVE_POPPLER_0_36)
-
-  set(CMAKE_REQUIRED_INCLUDES)
-  set(CMAKE_REQUIRED_LIBRARIES)
-  if (HAVE_POPPLER_0_28)
-    set(popplerVersionMessage "0.28")
-  elseif (HAVE_POPPLER_0_24)
-    set(popplerVersionMessage "0.24")
-  elseif (HAVE_POPPLER_0_36)
-    set(popplerVersionMessage "0.36")
-  endif ()
-  if (NOT Poppler_FIND_QUIETLY)
-    message(STATUS "Found Poppler-Qt5: ${POPPLER_LIBRARY}, (>= ${popplerVersionMessage})")
-  endif (NOT Poppler_FIND_QUIETLY)
-else (POPPLER_FOUND)
-  if (Poppler_FIND_REQUIRED)
-    message(FATAL_ERROR "Could NOT find Poppler-Qt5")
-  endif (Poppler_FIND_REQUIRED)
-  message(STATUS "Could not find OPTIONAL package Poppler-Qt5")
-endif (POPPLER_FOUND)
-
-# ensure that they are cached
-set(POPPLER_INCLUDE_DIR ${POPPLER_INCLUDE_DIR} CACHE INTERNAL "The Poppler-Qt5 include path")
-set(POPPLER_LIBRARY ${POPPLER_LIBRARY} CACHE INTERNAL "The Poppler-Qt5 library")
-
-endif(POPPLER_INCLUDE_DIR AND POPPLER_LIBRARY)
+include(FeatureSummary)
+set_package_properties(Poppler PROPERTIES
+    DESCRIPTION "A PDF rendering library"
+    URL "http://poppler.freedesktop.org"
+)


### PR DESCRIPTION
These patches enable travis builds of the KF5 component. The build-deps are for xenial (kdoctools-dev becomes kf5doctools-dev in later releases... we should remember that later!). For xenial, a newer version of FindPoppler.cmake is needed too as the old one doesn't actually find poppler. For later Debian and Ubuntu releases, extra-cmake-modules contains this newer FindPoppler.cmake and obsoletes this local file entirely.

The included FindPoppler.cmake relies on extra-cmake-modules package being installed; do you want to add that to the general linux build-deps?