### PR TITLE
Switch documentation to DocBook 4.5

### DIFF
--- a/doc/index.docbook
+++ b/doc/index.docbook
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<!DOCTYPE book PUBLIC "-//KDE//DTD DocBook XML V4.2-Based Variant V1.1//EN" "dtd/kdex.dtd" [
+<!DOCTYPE book PUBLIC "-//KDE//DTD DocBook XML V4.5-Based Variant V1.1//EN" "dtd/kdedbx45.dtd" [
   <!ENTITY ktikz "<application>KtikZ</application>">
   <!ENTITY kappname "&ktikz;">
   <!ENTITY poppler "<application>poppler</application>">


### PR DESCRIPTION
Luckly only the change of doctype is needed, and kdelibs4support is no more required to build it.