### PR TITLE
Add %F placeholder in desktop files

### DIFF
--- a/data/ktikz.desktop
+++ b/data/ktikz.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=KtikZ
-Exec=ktikz
+Exec=ktikz %F
 Icon=ktikz
 Terminal=false
 MimeType=text/x-pgf;text/x-tex;

--- a/data/qtikz.desktop.template
+++ b/data/qtikz.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=QtikZ
-Exec=qtikz
+Exec=qtikz %F
 Icon=
 Terminal=false
 MimeType=text/x-pgf;text/x-tex;


### PR DESCRIPTION
Both qtikz, and ktikz can open any number of local files passed as command line arguments; hence, add the `%F` placeholder to the `Exec` key in their desktop files.