### PR TITLE
Use target-arch pkg-config not local arch

### DIFF
--- a/qmake/findpoppler.pri
+++ b/qmake/findpoppler.pri
@@ -1,12 +1,13 @@
 unix:!macx {
 #	QMAKE_CXXFLAGS += `pkg-config --cflags poppler-qt4`
 #	QMAKE_LFLAGS += `pkg-config --libs poppler-qt4` # using this, qmake adds 3 times "--libs" to the LFLAGS, which is not recognized by g++ 4.6
+	PKG_CONFIG = $$pkgConfigExecutable()
 	greaterThan(QT_MAJOR_VERSION, 4) {
-		POPPLERINCLUDES = $$system(pkg-config --cflags poppler-qt5)
-		POPPLERLIBS = $$system(pkg-config --libs poppler-qt5)
+		POPPLERINCLUDES = $$system($$PKG_CONFIG --cflags poppler-qt5)
+		POPPLERLIBS = $$system($$PKG_CONFIG --libs poppler-qt5)
 	} else {
-		POPPLERINCLUDES = $$system(pkg-config --cflags poppler-qt4)
-		POPPLERLIBS = $$system(pkg-config --libs poppler-qt4)
+		POPPLERINCLUDES = $$system($$PKG_CONFIG --cflags poppler-qt4)
+		POPPLERLIBS = $$system($$PKG_CONFIG --libs poppler-qt4)
 	}
 	QMAKE_CXXFLAGS += $$POPPLERINCLUDES
 	QMAKE_LFLAGS += $$POPPLERLIBS

--- a/qmake/qtikzmacros.pri
+++ b/qmake/qtikzmacros.pri
@@ -3,12 +3,13 @@
 unix:!macx {
 #	QMAKE_CXXFLAGS += `pkg-config --cflags poppler-qt4`
 #	QMAKE_LFLAGS += `pkg-config --libs poppler-qt4` # using this, qmake adds 3 times "--libs" to the LFLAGS, which is not recognized by g++ 4.6
+	PKG_CONFIG = $$pkgConfigExecutable()
 	greaterThan(QT_MAJOR_VERSION, 4) {
-		POPPLERINCLUDES = $$system(pkg-config --cflags poppler-qt5)
-		POPPLERLIBS = $$system(pkg-config --libs poppler-qt5)
+		POPPLERINCLUDES = $$system($$PKG_CONFIG --cflags poppler-qt5)
+		POPPLERLIBS = $$system($$PKG_CONFIG --libs poppler-qt5)
 	} else {
-		POPPLERINCLUDES = $$system(pkg-config --cflags poppler-qt4)
-		POPPLERLIBS = $$system(pkg-config --libs poppler-qt4)
+		POPPLERINCLUDES = $$system($$PKG_CONFIG --cflags poppler-qt4)
+		POPPLERLIBS = $$system($$PKG_CONFIG --libs poppler-qt4)
 	}
 	QMAKE_CXXFLAGS += $$POPPLERINCLUDES
 	QMAKE_LFLAGS += $$POPPLERLIBS


### PR DESCRIPTION
ktikz fails to cross build from source (i.e. build for arm64 on amd64),
because it searches for poppler-qt* using the build architecture pkg-config.
This patch makes it use the requested pkg-config and that's sufficient to make
ktikz cross buildable.

(Patch from Helmut Grohne <helmutg@debian.org> as part of the cross-building /
bootstrapping project)