### PR TITLE
add extra-cmake-modules dependency for ubuntu

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -20,6 +20,7 @@ In Ubuntu 18.04 LTS you would obtain those by installing the following packages:
 - libkf5doctools-dev, libkf5xmlgui-dev, libkf5texteditor-dev, libkf5parts-dev, libkf5iconthemes-dev
 - pgf
 - preview-latex-style
+- extra-cmake-modules
 
 Install the Qt-only (qtikz) application (using qmake):
 ------------------------------------------------------


### PR DESCRIPTION
Before installing this package I had the following error:
```
CMake Error at CMakeLists.txt:12 (find_package):
  Could not find a package configuration file provided by "ECM" (requested
  version 1.1.0) with any of the following names:

    ECMConfig.cmake
    ecm-config.cmake

  Add the installation prefix of "ECM" to CMAKE_PREFIX_PATH or set "ECM_DIR"
  to a directory containing one of the above files.  If "ECM" provides a
  separate development package or SDK, be sure it has been installed.


-- Configuring incomplete, errors occurred!
```

Installing this packet fixes it.
https://superuser.com/a/1303466
