### PR TITLE
Use `WriteOnly` flag when writing file

### DIFF
--- a/common/utils/file.cpp
+++ b/common/utils/file.cpp
@@ -109,7 +109,7 @@ bool File::open(const QFile::OpenMode &mode)
 	{
 		m_errorString.clear();
 		//return dynamic_cast<KSaveFile*>(m_file)->open(); // XXX cannot use qobject_cast because QSaveFile doesn't have the Q_OBJECT macro
-		return m_file->open( QFile::ReadWrite ); // XXX cannot use qobject_cast because QSaveFile doesn't have the Q_OBJECT macro
+		return m_file->open( QFile::WriteOnly ); // XXX cannot use qobject_cast because QSaveFile doesn't have the Q_OBJECT macro
 	}
 	else if (m_openMode == ReadOnly)
 	{


### PR DESCRIPTION
I have no idea why `QFile::ReadWrite` is used here. It seems that `QFile::WriteOnly` is sufficient. And `QFile::WriteOnly` implies `QFile::Truncate`, which will fix #30 .