### PR TITLE
Remove support for Qt<=5.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(ktikz)
 cmake_minimum_required(VERSION 3.16.0)
+project(ktikz)
 
 set(KTIKZ_VERSION "0.13.2")
 

--- a/app/aboutdialog.cpp
+++ b/app/aboutdialog.cpp
@@ -18,17 +18,10 @@
 
 #include "aboutdialog.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QDialogButtonBox>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QTextBrowser>
 #include <QtWidgets/QVBoxLayout>
-#else
-#include <QtGui/QDialogButtonBox>
-#include <QtGui/QLabel>
-#include <QtGui/QTextBrowser>
-#include <QtGui/QVBoxLayout>
-#endif
 
 #include "ktikzapplication.h"
 

--- a/app/aboutdialog.h
+++ b/app/aboutdialog.h
@@ -20,11 +20,7 @@
 #define ABOUTDIALOG_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QDialog>
-#else
-#include <QtGui/QDialog>
-#endif
 
 class AboutDialog : public QDialog
 {

--- a/app/assistantcontroller.cpp
+++ b/app/assistantcontroller.cpp
@@ -22,11 +22,7 @@
 #include <QtCore/QDir>
 #include <QtCore/QLibraryInfo>
 #include <QtCore/QProcess>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QMessageBox>
-#else
-#include <QtGui/QMessageBox>
-#endif
 
 #include "ktikzapplication.h"
 

--- a/app/configappearancewidget.cpp
+++ b/app/configappearancewidget.cpp
@@ -20,13 +20,8 @@
 
 #include <QtCore/QSettings>
 #include <QtGui/QTextCharFormat>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QButtonGroup>
-#else
-#include <QtGui/QApplication>
-#include <QtGui/QButtonGroup>
-#endif
 
 #include "../common/utils/colordialog.h"
 #include "../common/utils/fontdialog.h"

--- a/app/configappearancewidget.h
+++ b/app/configappearancewidget.h
@@ -20,11 +20,7 @@
 #define KTIKZ_CONFIGAPPEARANCEWIDGET_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QWidget>
-#else
-#include <QtGui/QWidget>
-#endif
 #include "ui_configappearancewidget.h"
 
 class QTableWidgetItem;

--- a/app/configeditorwidget.cpp
+++ b/app/configeditorwidget.cpp
@@ -23,11 +23,7 @@
 
 #include <QtCore/QSettings>
 #include <QTextCodec>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
-#else
-#include <QtGui/QApplication>
-#endif
 
 #include "../common/utils/fontdialog.h"
 

--- a/app/editreplacecurrentwidget.cpp
+++ b/app/editreplacecurrentwidget.cpp
@@ -19,17 +19,10 @@
 #include "editreplacecurrentwidget.h"
 
 #include <QtGui/QKeyEvent>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
 #include <QtWidgets/QPushButton>
 #include <QtWidgets/QVBoxLayout>
-#else
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QPushButton>
-#include <QtGui/QVBoxLayout>
-#endif
 
 #include "../common/utils/icon.h"
 

--- a/app/editreplacecurrentwidget.h
+++ b/app/editreplacecurrentwidget.h
@@ -20,11 +20,7 @@
 #define REPLACECURRENTWIDGET_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QWidget>
-#else
-#include <QtGui/QWidget>
-#endif
 
 class QLabel;
 class QPushButton;

--- a/app/editreplacewidget.cpp
+++ b/app/editreplacewidget.cpp
@@ -18,9 +18,7 @@
 
 #include "editreplacewidget.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 #include <QtWidgets/QLineEdit>
-#endif
 
 #ifdef KTIKZ_USE_KDE
 #include <KCompletion>
@@ -33,15 +31,10 @@
 ReplaceWidget::ReplaceWidget(QWidget *parent) : QWidget(parent)
 {
 	ui.setupUi(this);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 	ui.comboBoxFind->setEditable(true);
 	ui.comboBoxReplace->setEditable(true);
 	ui.comboBoxFind->lineEdit()->setClearButtonEnabled(true);
 	ui.comboBoxReplace->lineEdit()->setClearButtonEnabled(true);
-#else
-	ui.comboBoxFind->setLineEdit(new LineEdit(this));
-	ui.comboBoxReplace->setLineEdit(new LineEdit(this));
-#endif
 	ui.pushButtonClose->setIcon(Icon(QLatin1String("dialog-cancel")));
 	ui.pushButtonBackward->setIcon(Icon(QLatin1String("go-up")));
 	ui.pushButtonForward->setIcon(Icon(QLatin1String("go-down")));

--- a/app/linenumberwidget.h
+++ b/app/linenumberwidget.h
@@ -20,11 +20,7 @@
 #define LINENUMBERWIDGET_H
 
 #include <QtGui/QPen>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QWidget>
-#else
-#include <QtGui/QWidget>
-#endif
 
 class TikzEditor;
 

--- a/app/logtextedit.cpp
+++ b/app/logtextedit.cpp
@@ -16,13 +16,9 @@
  *   along with this program; if not, see <http://www.gnu.org/licenses/>.  *
  ***************************************************************************/
 
-#include "logtextedit.h"
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
-#else
-#include <QtGui/QApplication>
-#endif
+
+#include "logtextedit.h"
 #include "loghighlighter.h"
 
 LogTextEdit::LogTextEdit(QWidget *parent) : QTextEdit(parent)

--- a/app/logtextedit.h
+++ b/app/logtextedit.h
@@ -20,11 +20,7 @@
 #define LOGTEXTEDIT_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QTextEdit>
-#else
-#include <QtGui/QTextEdit>
-#endif
 
 class QSyntaxHighlighter;
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -48,7 +48,6 @@ static struct { const char *source; const char *comment; } copyrightString = QT_
 	"Copyright (C) <YEAR> <NAME>.\" in which you fill in the year(s) of "
 	"translation and your name.");
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 static void debugOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
 	// qDebug() and qWarning() only show messages when in debug mode
@@ -70,27 +69,6 @@ static void debugOutput(QtMsgType type, const QMessageLogContext &context, const
 			abort();
 	}
 }
-#else
-static void debugOutput(QtMsgType type, const char *msg)
-{
-	// qDebug() and qWarning() only show messages when in debug mode
-	switch (type)
-	{
-		case QtDebugMsg:
-		case QtWarningMsg:
-#ifndef QT_NO_DEBUG
-			fprintf(stderr, "%s\n", msg);
-#endif
-			break;
-		case QtCriticalMsg:
-			fprintf(stderr, "%s\n", msg);
-			break;
-		case QtFatalMsg:
-			fprintf(stderr, "Fatal: %s\n", msg);
-			abort();
-	}
-}
-#endif
 
 static bool findTranslator(QTranslator *translator, const QString &transName, const QString &transDir)
 {
@@ -126,11 +104,7 @@ int main(int argc, char **argv)
 //QTime t = QTime::currentTime();
 	Q_UNUSED(copyrightString);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 	qInstallMessageHandler(debugOutput);
-#else
-	qInstallMsgHandler(debugOutput);
-#endif
 
 #ifndef KTIKZ_USE_KDE
 	// discard session (X11 calls QApplication::saveState() also when the app

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -44,7 +44,6 @@
 #include <QtCore/QTimer>
 #include <QtGui/QCloseEvent>
 #include <QtGui/QDesktopServices>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QDesktopWidget>
 #include <QtWidgets/QDockWidget>
 #include <QtWidgets/QLabel>
@@ -55,18 +54,6 @@
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QVBoxLayout>
 #include <QtWidgets/QWhatsThis>
-#else
-#include <QtGui/QDesktopWidget>
-#include <QtGui/QDockWidget>
-#include <QtGui/QLabel>
-#include <QtGui/QMessageBox>
-#include <QtGui/QPlainTextEdit>
-#include <QtGui/QPushButton>
-#include <QtGui/QToolBar>
-#include <QtGui/QToolButton>
-#include <QtGui/QVBoxLayout>
-#include <QtGui/QWhatsThis>
-#endif
 
 #include "configdialog.h"
 #include "ktikzapplication.h"

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -27,14 +27,12 @@
 #include <KXmlGuiWindow>
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QMainWindow>
-#else
-#include <QtGui/QMainWindow>
-#endif
+
 class AboutDialog;
 class AssistantController;
 #endif
+
 #include <QtCore/QDateTime>
 #include <QtCore/QPointer>
 #include "../common/mainwidget.h"

--- a/app/tikzcommandinserter.cpp
+++ b/app/tikzcommandinserter.cpp
@@ -25,16 +25,13 @@
 #endif
 
 #include <QtCore/QFile>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonParseError>
 #include <QtCore/QJsonValue>
-#endif
 #include <QtCore/QXmlStreamReader>
 #include <QtGui/QTextCursor>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDockWidget>
 #include <QtWidgets/QGridLayout>
@@ -44,17 +41,6 @@
 #include <QtWidgets/QPlainTextEdit>
 #include <QtWidgets/QStackedWidget>
 #include <QtWidgets/QToolTip>
-#else
-#include <QtGui/QApplication>
-#include <QtGui/QDockWidget>
-#include <QtGui/QGridLayout>
-#include <QtGui/QLabel>
-#include <QtGui/QListWidget>
-#include <QtGui/QMenu>
-#include <QtGui/QPlainTextEdit>
-#include <QtGui/QStackedWidget>
-#include <QtGui/QToolTip>
-#endif
 
 #include "tikzeditorhighlighter.h"
 #include "tikzcommandwidget.h"
@@ -192,30 +178,7 @@ static TikzCommandList getChildCommands(QXmlStreamReader *xml, QList<TikzCommand
 
 	return commandList;
 }
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-static TikzCommandList getCommands(QXmlStreamReader *xml, QList<TikzCommand> *tikzCommandsList)
-{
-	TikzCommandList commandList;
 
-	QFile tagsFile(QLatin1String(":/tikzcommands.xml"));
-	if (!tagsFile.open(QFile::ReadOnly))
-		return commandList;
-
-	xml->setDevice(&tagsFile);
-	if (xml->readNextStartElement())
-	{
-		if (xml->name() == QLatin1String("tikzcommands"))
-			commandList = getChildCommands(xml, tikzCommandsList);
-		else
-			xml->raiseError(QApplication::translate("TikzCommandInserter", "Cannot parse the TikZ commands file."));
-	}
-	if (xml->error()) // this should never happen in a final release because tikzcommands.xml is built in the binary
-		qCritical("Parse error in TikZ commands file at line %d, column %d:\n%s", int(xml->lineNumber()), int(xml->columnNumber()), qPrintable(xml->errorString()));
-	return commandList;
-}
-#endif
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 static TikzCommandList loadChildCommandsJson(QJsonObject sectionObject, QList<TikzCommand> *tikzCommandsList)
 {
 	TikzCommandList commandList;
@@ -303,19 +266,13 @@ static TikzCommandList loadCommandsJson(const QString &fileName, QList<TikzComma
 	}
 	return commandList;
 }
-#endif // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 
 void TikzCommandInserter::loadCommands()
 {
 	if (!m_tikzSections.commands.isEmpty())
 		return; // don't load the commands again when opening a second window
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 	m_tikzSections = loadCommandsJson(QLatin1String(":/tikzcommands.json"), &m_tikzCommandsList);
-#else // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-	QXmlStreamReader xml;
-	m_tikzSections = getCommands(&xml, &m_tikzCommandsList);
-#endif // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 }
 
 /***************************************************************************/
@@ -404,13 +361,7 @@ void TikzCommandInserter::updateDescriptionToolTip()
 		description.replace(QLatin1Char('>'), QLatin1String("&gt;"));
 		QMenu *menu = qobject_cast<QMenu*>(action->parentWidget());
 		const QRect rect = menu->actionGeometry(action);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
-//		QToolTip::showText(menu->mapToGlobal(rect.topRight()), QLatin1String("<p>") + description + QLatin1String("</p>"), menu, rect, 5000);
 		QToolTip::showText(menu->mapToGlobal(QPoint(rect.x() + rect.width(), rect.y() - rect.height() / 2)), QLatin1String("<p>") + description + QLatin1String("</p>"), menu, rect, 5000);
-#else
-//		QToolTip::showText(menu->mapToGlobal(rect.topRight()), QLatin1String("<p>") + description + QLatin1String("</p>"), menu, rect);
-		QToolTip::showText(menu->mapToGlobal(QPoint(rect.x() + rect.width(), rect.y() - rect.height() / 2)), QLatin1String("<p>") + description + QLatin1String("</p>"), menu, rect);
-#endif
 	}
 }
 

--- a/app/tikzcommandwidget.h
+++ b/app/tikzcommandwidget.h
@@ -20,11 +20,7 @@
 #define TIKZCOMMANDWIDGET_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QWidget>
-#else
-#include <QtGui/QWidget>
-#endif
 
 class TikzCommandWidget : public QWidget
 {

--- a/app/tikzeditor.cpp
+++ b/app/tikzeditor.cpp
@@ -41,20 +41,12 @@
 #include <QtGui/QPalette>
 #include <QtGui/QTextBlock>
 #include <QtGui/QTextLayout>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QAbstractItemView>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QCompleter>
 #include <QtWidgets/QScrollBar>
 #include <QtGui/QPainterPath>
 #include <QtCore/QStringListModel>
-#else
-#include <QtGui/QAbstractItemView>
-#include <QtGui/QApplication>
-#include <QtGui/QCompleter>
-#include <QtGui/QScrollBar>
-#include <QtGui/QStringListModel>
-#endif
 
 #include "linenumberwidget.h"
 

--- a/app/tikzeditor.h
+++ b/app/tikzeditor.h
@@ -21,11 +21,7 @@
 #define TIKZEDITOR_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QPlainTextEdit>
-#else
-#include <QtGui/QPlainTextEdit>
-#endif
 
 class QCompleter;
 class QLabel;

--- a/app/tikzeditorhighlighter.cpp
+++ b/app/tikzeditorhighlighter.cpp
@@ -19,15 +19,10 @@
  ***************************************************************************/
 
 #include <QDebug>
-#include "tikzeditorhighlighter.h"
-
 #include <QtCore/QSettings>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
-#else
-#include <QtGui/QApplication>
-#endif
 
+#include "tikzeditorhighlighter.h"
 #include "tikzcommandinserter.h"
 
 TikzHighlighter::TikzHighlighter(QTextDocument *parent)

--- a/app/tikzeditorview.cpp
+++ b/app/tikzeditorview.cpp
@@ -23,15 +23,9 @@
 #include <QtCore/QPointer>
 #include <QtCore/QSettings>
 #include <QtGui/QTextCursor>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QToolBar>
-#else
-#include <QtGui/QApplication>
-#include <QtGui/QMenu>
-#include <QtGui/QToolBar>
-#endif
 
 #include "configeditorwidget.h"
 #include "editgotolinewidget.h"

--- a/app/tikzeditorview.h
+++ b/app/tikzeditorview.h
@@ -20,12 +20,8 @@
 #define TIKZEDITORVIEW_H
 
 #include <QtGui/QTextDocument>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QWidget>
-#else
-#include <QtGui/QWidget>
-#endif
-//#include "tikzcommandinserter.h"
+
 #include "tikzeditorviewabstract.h"
 
 class QAction;

--- a/app/usercommandinserter.cpp
+++ b/app/usercommandinserter.cpp
@@ -20,11 +20,7 @@
 
 #include <QtCore/QPointer>
 #include <QtCore/QSettings>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QMenu>
-#else
-#include <QtGui/QMenu>
-#endif
 
 #include "tikzcommandinserter.h"
 #include "usercommandeditdialog.h"

--- a/common/templatewidget.cpp
+++ b/common/templatewidget.cpp
@@ -27,12 +27,8 @@
 #include <QtCore/QSettings>
 #include <QtGui/QKeyEvent>
 #include <QtGui/QTextDocument>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QLineEdit>
-#else
-#include <QtGui/QApplication>
-#endif
 
 #include "utils/combobox.h"
 #include "utils/filedialog.h"
@@ -44,12 +40,8 @@
 TemplateWidget::TemplateWidget(QWidget *parent) : QWidget(parent)
 {
 	ui.setupUi(this);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 2, 0)
 	ui.templateCombo->setEditable(true);
 	ui.templateCombo->lineEdit()->setClearButtonEnabled(true);
-#else
-	ui.templateCombo->setLineEdit(new LineEdit(this)); // slow
-#endif
 	ui.templateCombo->setMinimumContentsLength(20);
 	ui.templateChooseButton->setIcon(Icon(QLatin1String("document-open")));
 #ifdef KTIKZ_KPART
@@ -126,11 +118,7 @@ void TemplateWidget::setReplaceText(const QString &replace)
 	                                     "included and which will be typesetted to produce the preview "
 	                                     "image.  The string %1 in the template will be replaced by the "
 	                                     "TikZ code.</p>")
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 	                                     .arg(replace.toHtmlEscaped()));
-#else
-	                                     .arg(Qt::escape(replace)));
-#endif
 	ui.templateCombo->setWhatsThis(tr("<p>Give the file name of the LaTeX "
 	                                  "template.  If this input field is empty or contains an invalid "
 	                                  "file name, an internal default template will be used.</p>")

--- a/common/tikzpreview.cpp
+++ b/common/tikzpreview.cpp
@@ -18,11 +18,7 @@
 
 #include "tikzpreview.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <poppler-qt5.h>
-#else
-#include <poppler-qt4.h>
-#endif
 
 #include <QSettings>
 #include <QApplication>

--- a/common/tikzpreview.h
+++ b/common/tikzpreview.h
@@ -20,11 +20,8 @@
 #define KTIKZ_TIKZPREVIEW_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QGraphicsView>
-#else
-#include <QtGui/QGraphicsView>
-#endif
+
 #include "tikzpreviewmessagewidget.h"
 
 class QToolBar;

--- a/common/tikzpreviewcontroller.cpp
+++ b/common/tikzpreviewcontroller.cpp
@@ -21,30 +21,17 @@
 #include "tikzpreviewcontroller.h"
 
 #ifndef KTIKZ_USE_KDE
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QToolBar>
-#else
-#include <QtGui/QToolBar>
-#endif
 #endif
 
 #include <QtCore/QSettings>
 #include <QtCore/QTimer>
 #include <QtCore/QPointer>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtPrintSupport/QPrintDialog>
 #include <QtPrintSupport/QPrinter>
 #include <QtWidgets/QDialogButtonBox>
 #include <QtWidgets/QMenu>
 #include <QtWidgets/QPushButton>
-#else
-#include <QtGui/QDialogButtonBox>
-#include <QtGui/QMenu>
-#include <QtGui/QPrintDialog>
-#include <QtGui/QPrinter>
-#include <QtGui/QPushButton>
-// #include <KConfigGroup> // JC
-#endif
 
 #include "templatewidget.h"
 #include "tikzpreview.h"

--- a/common/tikzpreviewgenerator.cpp
+++ b/common/tikzpreviewgenerator.cpp
@@ -30,14 +30,9 @@
 #include <QtCore/QProcess>
 #include <QtCore/QTextStream>
 #include <QtGui/QPixmap>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtCore/QStandardPaths>
 #include <QtWidgets/QPlainTextEdit>
 #include <poppler-qt5.h>
-#else
-#include <QtGui/QPlainTextEdit>
-#include <poppler-qt4.h>
-#endif
 
 #include "tikzpreviewcontroller.h"
 #include "mainwidget.h"
@@ -58,9 +53,6 @@ TikzPreviewGenerator::TikzPreviewGenerator(TikzPreviewController *parent)
 	, m_firstRun(true)
 	, m_templateChanged(true) // is set correctly in generatePreviewImpl()
 	, m_useShellEscaping(false) // is set in setShellEscaping() at startup
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	, m_checkGnuplotExecutable(0)
-#endif // QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 {
 	qRegisterMetaType<TemplateStatus>("TemplateStatus"); // needed for Q_ARG below
 
@@ -111,42 +103,13 @@ void TikzPreviewGenerator::setShellEscaping(bool useShellEscaping)
 
 	if (useShellEscaping)
 	{
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 		QString gnuplotPath = QStandardPaths::findExecutable(QLatin1String("gnuplot")); // search in system path
 		if (gnuplotPath.isEmpty() || !QFileInfo(gnuplotPath).isExecutable()) // not found
 			Q_EMIT showErrorMessage(tr("Gnuplot cannot be executed.  Either Gnuplot is not installed "
 			                           "or it is not available in the system PATH or you may have insufficient "
 			                           "permissions to invoke the program."));
-#else // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-		m_checkGnuplotExecutable = new QProcess;
-		m_checkGnuplotExecutable->start(QLatin1String("gnuplot"), QStringList() << QLatin1String("--version"));
-//		m_checkGnuplotExecutable->moveToThread(&m_thread);
-		connect(m_checkGnuplotExecutable, SIGNAL(error(QProcess::ProcessError)), this, SLOT(displayGnuplotNotExecutable()));
-		connect(m_checkGnuplotExecutable, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(checkGnuplotExecutableFinished(int,QProcess::ExitStatus)));
-#endif // QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 	}
 }
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-void TikzPreviewGenerator::displayGnuplotNotExecutable()
-{
-	Q_EMIT showErrorMessage(tr("Gnuplot cannot be executed.  Either Gnuplot is not installed "
-	                           "or it is not available in the system PATH or you may have insufficient "
-	                           "permissions to invoke the program."));
-	const QMutexLocker lock(&m_memberLock);
-	m_checkGnuplotExecutable->deleteLater();
-//	m_checkGnuplotExecutable = 0;
-}
-
-void TikzPreviewGenerator::checkGnuplotExecutableFinished(int exitCode, QProcess::ExitStatus exitStatus)
-{
-	Q_UNUSED(exitCode)
-	Q_UNUSED(exitStatus)
-	const QMutexLocker lock(&m_memberLock);
-	m_checkGnuplotExecutable->deleteLater();
-//	m_checkGnuplotExecutable = 0;
-}
-#endif // QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 
 void TikzPreviewGenerator::setTemplateFile(const QString &fileName)
 {

--- a/common/tikzpreviewgenerator.h
+++ b/common/tikzpreviewgenerator.h
@@ -83,10 +83,6 @@ Q_SIGNALS:
 	void processRunning(bool isRunning);
 
 private Q_SLOTS:
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	void displayGnuplotNotExecutable();
-	void checkGnuplotExecutableFinished(int exitCode, QProcess::ExitStatus exitStatus);
-#endif // QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 	void generatePreviewImpl(TemplateStatus templateStatus = DontReloadTemplate);
 
 protected:
@@ -119,10 +115,6 @@ protected:
 	QString m_shortLogText;
 	QString m_logText;
 	bool m_useShellEscaping;
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-	QProcess *m_checkGnuplotExecutable;
-#endif // QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 };
 
 #endif

--- a/common/tikzpreviewmessagewidget.cpp
+++ b/common/tikzpreviewmessagewidget.cpp
@@ -18,13 +18,8 @@
 
 #include "tikzpreviewmessagewidget.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QHBoxLayout>
 #include <QtWidgets/QLabel>
-#else
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QLabel>
-#endif
 #ifdef KTIKZ_USE_KDE
 #include <KIconLoader>
 #endif

--- a/common/tikzpreviewmessagewidget.h
+++ b/common/tikzpreviewmessagewidget.h
@@ -20,11 +20,7 @@
 #define KTIKZ_TIKZPREVIEWMESSAGEWIDGET_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QFrame>
-#else
-#include <QtGui/QFrame>
-#endif
 
 class QLabel;
 

--- a/common/tikzpreviewrenderer.cpp
+++ b/common/tikzpreviewrenderer.cpp
@@ -19,11 +19,7 @@
 #include "tikzpreviewrenderer.h"
 
 #include <QtGui/QImage>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <poppler-qt5.h>
-#else
-#include <poppler-qt4.h>
-#endif
 
 TikzPreviewRenderer::TikzPreviewRenderer()
 {

--- a/common/utils/colorbutton.cpp
+++ b/common/utils/colorbutton.cpp
@@ -25,13 +25,8 @@
 
 #ifndef KTIKZ_USE_KDE
 #include <QtGui/QPainter>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QColorDialog>
-#else
-#include <QtGui/QApplication>
-#include <QtGui/QColorDialog>
-#endif
 
 ColorButton::ColorButton(QWidget *parent) : QToolButton(parent)
 {

--- a/common/utils/colorbutton.h
+++ b/common/utils/colorbutton.h
@@ -32,11 +32,7 @@ public:
 };
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QToolButton>
-#else
-#include <QtGui/QToolButton>
-#endif
 
 class ColorButton : public QToolButton
 {

--- a/common/utils/lineedit.cpp
+++ b/common/utils/lineedit.cpp
@@ -23,13 +23,9 @@ LineEdit::LineEdit(QWidget *parent)
   setClearButtonEnabled(true);
 }
 #else
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QToolButton>
 #include <QtWidgets/QStyle>
-#else
-#include <QtGui/QToolButton>
-#include <QtGui/QStyle>
-#endif
+
 #include "urlcompletion.h"
 
 LineEdit::LineEdit(const QString &text, QWidget *parent)

--- a/common/utils/lineedit.h
+++ b/common/utils/lineedit.h
@@ -24,11 +24,7 @@ public:
 };
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QLineEdit>
-#else
-#include <QtGui/QLineEdit>
-#endif
 
 class QToolButton;
 class UrlCompletion;

--- a/common/utils/messagebox.cpp
+++ b/common/utils/messagebox.cpp
@@ -47,13 +47,8 @@ void MessageBox::error(QWidget *parent, const QString &text, const QString &capt
 	KMessageBox::error(parent, text, caption);
 }
 #else
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QPushButton>
-#else
-#include <QtGui/QMessageBox>
-#include <QtGui/QPushButton>
-#endif
 
 int MessageBox::questionYesNo(QWidget *parent, const QString &text, const QString &caption, const QString &yesButtonText, const QString &noButtonText)
 {

--- a/common/utils/pagedialog.h
+++ b/common/utils/pagedialog.h
@@ -31,11 +31,7 @@ public:
 };
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QDialog>
-#else
-#include <QtGui/QDialog>
-#endif
 
 class QLabel;
 class QListWidget;

--- a/common/utils/printpreviewdialog.cpp
+++ b/common/utils/printpreviewdialog.cpp
@@ -18,13 +18,8 @@
 
 #include "printpreviewdialog.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtPrintSupport/QPrintPreviewWidget>
 #include <QtWidgets/QVBoxLayout>
-#else
-#include <QtGui/QPrintPreviewWidget>
-#include <QtGui/QVBoxLayout>
-#endif
 
 #include "action.h"
 #include "globallocale.h"

--- a/common/utils/printpreviewdialog.h
+++ b/common/utils/printpreviewdialog.h
@@ -20,11 +20,7 @@
 #define KTIKZ_PRINTPREVIEWDIALOG_H
 
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QDialog>
-#else
-#include <QtGui/QDialog>
-#endif
 
 class QPrinter;
 class QPrintPreviewWidget;

--- a/common/utils/recentfilesaction.cpp
+++ b/common/utils/recentfilesaction.cpp
@@ -61,11 +61,7 @@ void RecentFilesAction::saveEntries()
 }
 #else
 #include <QtCore/QSettings>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QMenu>
-#else
-#include <QtGui/QMenu>
-#endif
 
 RecentFilesAction::RecentFilesAction(QObject *parent)
 	: Action(parent)

--- a/common/utils/selectaction.cpp
+++ b/common/utils/selectaction.cpp
@@ -45,15 +45,9 @@ SelectAction::SelectAction(const Icon &icon, const QString &text, QObject *paren
 		Action::actionCollection()->addAction(name, this);
 }
 #else
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
 #include <QtWidgets/QWidgetAction>
-#else
-#include <QtGui/QComboBox>
-#include <QtGui/QLineEdit>
-#include <QtGui/QWidgetAction>
-#endif
 
 SelectAction::SelectAction(QObject *parent, const QString &name)
 	: QWidgetAction(parent)

--- a/common/utils/selectaction.h
+++ b/common/utils/selectaction.h
@@ -35,11 +35,7 @@ public:
 };
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QWidgetAction>
-#else
-#include <QtGui/QWidgetAction>
-#endif
 
 class QComboBox;
 

--- a/common/utils/toggleaction.h
+++ b/common/utils/toggleaction.h
@@ -35,11 +35,7 @@ public:
 };
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QAction>
-#else
-#include <QtGui/QAction>
-#endif
 
 class ToggleAction : public QAction
 {

--- a/common/utils/toolbar.h
+++ b/common/utils/toolbar.h
@@ -31,11 +31,7 @@ public:
 };
 #else
 #include <QtCore/QtGlobal>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QToolBar>
-#else
-#include <QtGui/QToolBar>
-#endif
 
 class ToolBar : public QToolBar
 {

--- a/common/utils/urlcompletion.h
+++ b/common/utils/urlcompletion.h
@@ -31,13 +31,8 @@ public:
 	}
 };
 #else
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtWidgets/QCompleter>
 #include <QtWidgets/QFileSystemModel>
-#else
-#include <QtGui/QCompleter>
-#include <QtGui/QFileSystemModel>
-#endif
 
 class UrlCompletion : public QCompleter
 {


### PR DESCRIPTION
I was hoping to slowly get qtikz / ktikz ported to Qt6 / KF6. This is a first small piece of that that does some code cleanup and removes some old ifdefs.

I'm planning on mostly making everything compile on Qt 5.15 without any deprecation warnings and then seeing about porting to Qt6 / KF6. What do you think? Is #58 still a ongoing?

