### PR TITLE
ci: add clang-format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  clang-format:
+    name: Formatting (clang-format)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format
+        uses: jidicula/clang-format-action@v4.11.0
+        with:
+          clang-format-version: '13'
+          check-path: '.'
+
   linux-qt:
     name: Build (Linux/Qt)
     runs-on: ubuntu-latest
@@ -66,7 +77,7 @@ jobs:
           cmake --build build
 
   macos:
-    name: Build (macOS)
+    name: Build (macOS/Qt)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This adds a job on the CI to run `clang-format` and make sure everything is still in order. It's based on https://github.com/jidicula/clang-format-action.