### PR TITLE
cmake: format using gersemi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,59 +1,75 @@
 cmake_minimum_required(VERSION 3.22.0)
 project(ktikz)
 
+if(POLICY CMP0160)
+    # NOTE: silence warnings in ECM (policy since cmake 3.29)
+    cmake_policy(SET CMP0160 OLD)
+endif()
+
 set(KTIKZ_VERSION "0.13.2")
+set(KTIKZ_USE_KTEXTEDITOR TRUE CACHE BOOL "Use KTextEditor framework")
 
-set(KTIKZ_USE_KTEXTEDITOR TRUE CACHE BOOL "Use KTextEditor framework" )
-
-add_definitions(-DORGNAME=\"Florian_Hackenberger\" -DAPPNAME=\"ktikz\")
+add_definitions(-DORGNAME=\"Florian_Hackenberger\")
+add_definitions(-DAPPNAME=\"ktikz\")
 add_definitions(-DAPPVERSION=\"${KTIKZ_VERSION}\")
 add_definitions(-DKTIKZ_USE_DESKTOP_ICONS)
 add_definitions(-DKTIKZ_USE_KDE)
-if( KTIKZ_USE_KTEXTEDITOR )
-  add_definitions(-DKTIKZ_USE_KTEXTEDITOR)
-endif()
 add_definitions(-DKTIKZ_TIKZ_DOCUMENTATION_DEFAULT=\"/usr/share/doc/texmf/pgf/pgfmanual.pdf.gz\")
+
+if(KTIKZ_USE_KTEXTEDITOR)
+    add_definitions(-DKTIKZ_USE_KTEXTEDITOR)
+endif()
 
 find_package(ECM 1.1.0 REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR})
+
 include(ECMSetupVersion)
 include(ECMAddAppIcon)
 include(ECMInstallIcons)
-
-find_package(Qt5 5.15 CONFIG REQUIRED Core Gui Widgets Xml PrintSupport LinguistTools )
-
-find_package(KF5 5.92 REQUIRED DocTools XmlGui TextEditor Parts IconThemes )
-
 include(KDEInstallDirs)
 include(KDECompilerSettings NO_POLICY_SCOPE)
 include(KDECMakeSettings)
 include(FeatureSummary)
-# include(KDEFrameworkCompilerSettings)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_definitions(-DQT_STRICT_ITERATORS)
+find_package(
+    Qt5
+    5.15
+    CONFIG
+    REQUIRED Core Gui Widgets Xml PrintSupport LinguistTools
+)
+
+find_package(
+    KF5
+    5.92
+    REQUIRED DocTools XmlGui TextEditor Parts IconThemes
+)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions(-DQT_STRICT_ITERATORS)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-   if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0.0")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wlogical-op" )
-   endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "5.0.0")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wlogical-op")
+    endif()
 endif()
 
 find_package(Poppler "22.02" REQUIRED Qt5 Core)
-set_package_properties("Poppler-Qt5" PROPERTIES
-        DESCRIPTION "A PDF rendering library"
-        URL "http://poppler.freedesktop.org"
-        TYPE REQUIRED
-        PURPOSE "Support for PDF files in KTikZ.")
+set_package_properties(
+    "Poppler-Qt5"
+    PROPERTIES
+    DESCRIPTION "A PDF rendering library"
+    URL "http://poppler.freedesktop.org"
+    TYPE REQUIRED
+    PURPOSE "Support for PDF files in KTikZ."
+)
 
 add_subdirectory(app)
 add_subdirectory(part)
-
 add_subdirectory(doc)
 add_subdirectory(translations)
 add_subdirectory(data)
@@ -61,7 +77,6 @@ add_subdirectory(data)
 # Remove directories
 add_custom_target(uninstalldirs)
 add_dependencies(uninstalldirs uninstalldirs_app uninstalldirs_part uninstalldirs_doc)
-# add_dependencies(uninstalldirs uninstalldirs_app uninstalldirs_doc)
 
 # Make packages
 include(KtikzCPackOptions.cmake)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,116 +1,121 @@
 include(../KtikzConfig.cmake)
-add_definitions("-DKTIKZ_TRANSLATIONS_INSTALL_DIR=\"${KTIKZ_TRANSLATIONS_INSTALL_DIR}\"")
-add_definitions("-DKTIKZ_TEMPLATES_INSTALL_DIR=\"${KTIKZ_TEMPLATES_INSTALL_DIR}\"")
+add_definitions(-DKTIKZ_TRANSLATIONS_INSTALL_DIR=\"${KTIKZ_TRANSLATIONS_INSTALL_DIR}\")
+add_definitions(-DKTIKZ_TEMPLATES_INSTALL_DIR=\"${KTIKZ_TEMPLATES_INSTALL_DIR}\")
 
 include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}/../common
-	${CMAKE_CURRENT_SOURCE_DIR}/../common/utils
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common/utils
 )
 
 set(ktikz_SRCS
-	configappearancewidget.cpp
-	configeditorwidget.cpp
-	configgeneralwidget.cpp
-	configpreviewwidget.cpp
-	configdialog.cpp
-	editgotolinewidget.cpp
-	editindentwidget.cpp
-	editreplacewidget.cpp
-	editreplacecurrentwidget.cpp
-	ktikzapplication.cpp
-	linenumberwidget.cpp
-	loghighlighter.cpp
-	logtextedit.cpp
-	main.cpp
-	mainwindow.cpp
-	tikzcommandinserter.cpp
-	tikzcommandwidget.cpp
-	tikzdocumentationcontroller.cpp
-	tikzeditor.cpp
-	tikzeditorhighlighter.cpp
-	tikzeditorview.cpp
-	usercommandeditdialog.cpp
-	usercommandinserter.cpp
-	../common/templatewidget.cpp
-	../common/tikzpreview.cpp
-	../common/tikzpreviewmessagewidget.cpp
-	../common/tikzpreviewrenderer.cpp
-	../common/tikzpreviewcontroller.cpp
-	../common/tikzpreviewgenerator.cpp
-	../common/utils/action.cpp
-	../common/utils/colorbutton.cpp
-	../common/utils/combobox.cpp
-	../common/utils/file.cpp
-	../common/utils/filedialog.cpp
-	../common/utils/globallocale.cpp
-	../common/utils/lineedit.cpp
-	../common/utils/messagebox.cpp
-	../common/utils/pagedialog.cpp
-	../common/utils/printpreviewdialog.cpp
-	../common/utils/recentfilesaction.cpp
-	../common/utils/selectaction.cpp
-	../common/utils/standardaction.cpp
-	../common/utils/tempdir.cpp
-	../common/utils/toggleaction.cpp
-	../common/utils/toolbar.cpp
-	../common/utils/url.cpp
-	../common/utils/zoomaction.cpp
+    configappearancewidget.cpp
+    configeditorwidget.cpp
+    configgeneralwidget.cpp
+    configpreviewwidget.cpp
+    configdialog.cpp
+    editgotolinewidget.cpp
+    editindentwidget.cpp
+    editreplacewidget.cpp
+    editreplacecurrentwidget.cpp
+    ktikzapplication.cpp
+    linenumberwidget.cpp
+    loghighlighter.cpp
+    logtextedit.cpp
+    main.cpp
+    mainwindow.cpp
+    tikzcommandinserter.cpp
+    tikzcommandwidget.cpp
+    tikzdocumentationcontroller.cpp
+    tikzeditor.cpp
+    tikzeditorhighlighter.cpp
+    tikzeditorview.cpp
+    usercommandeditdialog.cpp
+    usercommandinserter.cpp
+    ../common/templatewidget.cpp
+    ../common/tikzpreview.cpp
+    ../common/tikzpreviewmessagewidget.cpp
+    ../common/tikzpreviewrenderer.cpp
+    ../common/tikzpreviewcontroller.cpp
+    ../common/tikzpreviewgenerator.cpp
+    ../common/utils/action.cpp
+    ../common/utils/colorbutton.cpp
+    ../common/utils/combobox.cpp
+    ../common/utils/file.cpp
+    ../common/utils/filedialog.cpp
+    ../common/utils/globallocale.cpp
+    ../common/utils/lineedit.cpp
+    ../common/utils/messagebox.cpp
+    ../common/utils/pagedialog.cpp
+    ../common/utils/printpreviewdialog.cpp
+    ../common/utils/recentfilesaction.cpp
+    ../common/utils/selectaction.cpp
+    ../common/utils/standardaction.cpp
+    ../common/utils/tempdir.cpp
+    ../common/utils/toggleaction.cpp
+    ../common/utils/toolbar.cpp
+    ../common/utils/url.cpp
+    ../common/utils/zoomaction.cpp
 )
 
-if( KTIKZ_USE_KTEXTEDITOR )
-  list(APPEND ktikz_SRCS
-    tikzktexteditorview.cpp
-    tikzktexteditorcompletion.cpp
-  )
+if(KTIKZ_USE_KTEXTEDITOR)
+    list(APPEND ktikz_SRCS tikzktexteditorview.cpp tikzktexteditorcompletion.cpp)
 endif()
 
-# dirty hack: use ki18n_wrap_ui to let Qt translate the .ui files instead of KDE (to have less duplication in the translation effort)
+# dirty hack: use ki18n_wrap_ui to let Qt translate the .ui files instead of
+# KDE (to have less duplication in the translation effort)
 ki18n_wrap_ui(ktikz_UI_FILES
-	configappearancewidget.ui
-	configeditorwidget.ui
-	configgeneralwidget.ui
-	configpreviewwidget.ui
-	editgotolinewidget.ui
-	editindentwidget.ui
-	editreplacewidget.ui
-	usercommandeditdialog.ui
-	../common/templatewidget.ui
+    configappearancewidget.ui
+    configeditorwidget.ui
+    configgeneralwidget.ui
+    configpreviewwidget.ui
+    editgotolinewidget.ui
+    editindentwidget.ui
+    editreplacewidget.ui
+    usercommandeditdialog.ui
+    ../common/templatewidget.ui
 )
 kconfig_add_kcfg_files(ktikz_SRCS ../common/settings.kcfgc)
 qt5_add_resources(ktikz_SRCS ktikz.qrc)
 qt5_add_resources(ktikz_SRCS qtikz.qrc)
 
 file(GLOB icons_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/icons/*-apps-ktikz.png")
-ecm_add_app_icon(ktikz_SRCS ICONS ${icons_SRCS}) # add icons for win32 and mac; this command assumes that the first arg is of the form <appname>_SRCS
+# add icons for win32 and mac; this command assumes that the first arg is of the
+# form <appname>_SRCS
+ecm_add_app_icon(ktikz_SRCS ICONS ${icons_SRCS})
 
-# dirty hack: use ki18n_wrap_ui to let Qt translate the .ui files instead of KDE
 add_executable(ktikz ${ktikz_SRCS} ${ktikz_UI_FILES})
-target_link_libraries(ktikz
+target_link_libraries(
+    ktikz
     KF5::XmlGui
     KF5::TextEditor
     KF5::IconThemes
     Qt5::PrintSupport
-    Poppler::Qt5)
+    Poppler::Qt5
+)
 
-if( KTIKZ_USE_KTEXTEDITOR )
-  target_link_libraries(ktikz KF5::TextEditor)
+if(KTIKZ_USE_KTEXTEDITOR)
+    target_link_libraries(ktikz KF5::TextEditor)
 endif()
 
 install(TARGETS ktikz DESTINATION ${KDE_INSTALL_BINDIR})
-if( KTIKZ_USE_KTEXTEDITOR )
-  install(FILES ktikzui_frameworks.rc DESTINATION ${KXMLGUI_INSTALL_DIR}/ktikz)
+if(KTIKZ_USE_KTEXTEDITOR)
+    install(FILES ktikzui_frameworks.rc DESTINATION ${KXMLGUI_INSTALL_DIR}/ktikz)
 endif()
+
 install(FILES ktikzui.rc DESTINATION ${KXMLGUI_INSTALL_DIR}/ktikz)
 install(FILES ../common/ktikz.kcfg DESTINATION ${KDE_INSTALL_KCFGDIR})
 
 add_subdirectory(icons)
 
 add_custom_target(uninstalldirs_app)
-add_custom_command(TARGET uninstalldirs_app
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZ_TRANSLATIONS_INSTALL_DIR}
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZ_TEMPLATES_INSTALL_DIR}
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZ_DATA_INSTALL_DIR}
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${KXMLGUI_INSTALL_DIR}/ktikz
-	COMMENT "Removing directories ${KTIKZ_TRANSLATIONS_INSTALL_DIR} ${KTIKZ_TEMPLATES_INSTALL_DIR} ${KTIKZ_DATA_INSTALL_DIR} ${KXMLGUI_INSTALL_DIR}/ktikz"
-	VERBATIM)
+add_custom_command(
+    TARGET uninstalldirs_app
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZ_TRANSLATIONS_INSTALL_DIR}
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZ_TEMPLATES_INSTALL_DIR}
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZ_DATA_INSTALL_DIR}
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${KXMLGUI_INSTALL_DIR}/ktikz
+    COMMENT
+        "Removing directories ${KTIKZ_TRANSLATIONS_INSTALL_DIR} ${KTIKZ_TEMPLATES_INSTALL_DIR} ${KTIKZ_DATA_INSTALL_DIR} ${KXMLGUI_INSTALL_DIR}/ktikz"
+    VERBATIM
+)

--- a/app/icons/CMakeLists.txt
+++ b/app/icons/CMakeLists.txt
@@ -1,12 +1,13 @@
 # this installs the icons with a file name of the form <size>-<group>-<name>.<extension>, e.g. hi22-apps-ktikz.png
 ecm_install_icons(ICONS
-16-apps-ktikz.png
-22-apps-ktikz.png
-32-apps-ktikz.png
-48-apps-ktikz.png
-64-apps-ktikz.png
-128-apps-ktikz.png
-sc-apps-ktikz.svgz
-sc-apps-ktikz.svg
-DESTINATION ${KDE_INSTALL_ICONDIR}
-THEME hicolor )
+    16-apps-ktikz.png
+    22-apps-ktikz.png
+    32-apps-ktikz.png
+    48-apps-ktikz.png
+    64-apps-ktikz.png
+    128-apps-ktikz.png
+    sc-apps-ktikz.svgz
+    sc-apps-ktikz.svg
+    DESTINATION ${KDE_INSTALL_ICONDIR}
+    THEME hicolor
+)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,22 +1,21 @@
 include(../KtikzConfig.cmake)
 
 ### Install desktop file
-
 install(FILES ktikz.desktop DESTINATION ${KDE_INSTALL_APPDIR})
 
 ### Install text/x-pgf mimetype
-
 find_package(SharedMimeInfo)
 install(FILES qtikz.xml DESTINATION ${KDE_INSTALL_MIMEDIR} RENAME ktikz.xml)
 update_xdg_mimetypes(${KDE_INSTALL_MIMEDIR})
 
 ### Install examples
-
-install(FILES examples/template_example.pgs
-	examples/template_example2.pgs
-	examples/beamer-example-template.pgs
-	DESTINATION ${KTIKZ_TEMPLATES_INSTALL_DIR})
+install(
+    FILES
+        examples/template_example.pgs
+        examples/template_example2.pgs
+        examples/beamer-example-template.pgs
+    DESTINATION ${KTIKZ_TEMPLATES_INSTALL_DIR}
+)
 
 ### Install appdata file
-
 install(FILES ktikz.appdata.xml DESTINATION ${KDE_INSTALL_METAINFODIR})

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,19 +1,20 @@
 ### Install KDE Help Center documentation
-
-kdoctools_create_handbook(index.docbook
-	INSTALL_DESTINATION ${KDE_INSTALL_DOCBUNDLEDIR}/en
-	SUBDIR ktikz)
+kdoctools_create_handbook(
+    index.docbook
+    INSTALL_DESTINATION ${KDE_INSTALL_DOCBUNDLEDIR}/en
+    SUBDIR ktikz
+)
 
 ### Install man files
-
 install(FILES ktikz.1 DESTINATION ${KDE_INSTALL_MANDIR}/man1)
 
 ### Remove installation directories
-
 add_custom_target(uninstalldirs_doc)
-add_custom_command(TARGET uninstalldirs_doc
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E remove ${KDE_INSTALL_DOCBUNDLEDIR}/en/ktikz/common
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${KDE_INSTALL_DOCBUNDLEDIR}/en/ktikz
-	COMMENT "Removing directory ${KDE_INSTALL_DOCBUNDLEDIR}/en/ktikz"
-	VERBATIM)
+add_custom_command(
+    TARGET uninstalldirs_doc
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E remove ${KDE_INSTALL_DOCBUNDLEDIR}/en/ktikz/common
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${KDE_INSTALL_DOCBUNDLEDIR}/en/ktikz
+    COMMENT "Removing directory ${KDE_INSTALL_DOCBUNDLEDIR}/en/ktikz"
+    VERBATIM
+)

--- a/part/CMakeLists.txt
+++ b/part/CMakeLists.txt
@@ -1,72 +1,70 @@
 include(../KtikzConfig.cmake)
-add_definitions("-DKTIKZ_TRANSLATIONS_INSTALL_DIR=\"${KTIKZ_TRANSLATIONS_INSTALL_DIR}\"")
 
 set(KTIKZPART_DATA_INSTALL_DIR ${KDE_INSTALL_DATADIR}/ktikzpart)
-#add_definitions(-DORGNAME=\\\"Florian_Hackenberger\\\" -DAPPNAME=\\\"ktikz\\\")
 add_definitions(-DKTIKZ_KPART)
-
-include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}/../common
-)
+add_definitions(-DKTIKZ_TRANSLATIONS_INSTALL_DIR=\"${KTIKZ_TRANSLATIONS_INSTALL_DIR}\")
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../common)
 
 set(ktikzpart_SRCS
-	browserextension.cpp
-	configdialog.cpp
-	configgeneralwidget.cpp
-	part.cpp
-	../common/templatewidget.cpp
-	../common/tikzpreview.cpp
-	../common/tikzpreviewmessagewidget.cpp
-	../common/tikzpreviewrenderer.cpp
-	../common/tikzpreviewcontroller.cpp
-	../common/tikzpreviewgenerator.cpp
-	../common/utils/action.cpp
-	../common/utils/combobox.cpp
-	../common/utils/file.cpp
-	../common/utils/filedialog.cpp
-	../common/utils/globallocale.cpp
-	../common/utils/lineedit.cpp
-	../common/utils/messagebox.cpp
-	../common/utils/printpreviewdialog.cpp
-	../common/utils/recentfilesaction.cpp
-	../common/utils/selectaction.cpp
-	../common/utils/standardaction.cpp
-	../common/utils/tempdir.cpp
-	../common/utils/toggleaction.cpp
-	../common/utils/toolbar.cpp
-	../common/utils/url.cpp
-	../common/utils/zoomaction.cpp
+    browserextension.cpp
+    configdialog.cpp
+    configgeneralwidget.cpp
+    part.cpp
+    ../common/templatewidget.cpp
+    ../common/tikzpreview.cpp
+    ../common/tikzpreviewmessagewidget.cpp
+    ../common/tikzpreviewrenderer.cpp
+    ../common/tikzpreviewcontroller.cpp
+    ../common/tikzpreviewgenerator.cpp
+    ../common/utils/action.cpp
+    ../common/utils/combobox.cpp
+    ../common/utils/file.cpp
+    ../common/utils/filedialog.cpp
+    ../common/utils/globallocale.cpp
+    ../common/utils/lineedit.cpp
+    ../common/utils/messagebox.cpp
+    ../common/utils/printpreviewdialog.cpp
+    ../common/utils/recentfilesaction.cpp
+    ../common/utils/selectaction.cpp
+    ../common/utils/standardaction.cpp
+    ../common/utils/tempdir.cpp
+    ../common/utils/toggleaction.cpp
+    ../common/utils/toolbar.cpp
+    ../common/utils/url.cpp
+    ../common/utils/zoomaction.cpp
 )
 
-ki18n_wrap_ui(ktikzpart_SRCS
-	configgeneralwidget.ui
-	../common/templatewidget.ui
+ki18n_wrap_ui(
+    ktikzpart_SRCS
+    configgeneralwidget.ui
+    ../common/templatewidget.ui
 )
 
 kconfig_add_kcfg_files(ktikzpart_SRCS ../common/settings.kcfgc)
 
 add_library(ktikzpart MODULE ${ktikzpart_SRCS})
-
-target_link_libraries(ktikzpart
-  KF5::Parts
-  KF5::IconThemes
-  KF5::CoreAddons
-  KF5::KIOCore
-  KF5::KIOFileWidgets
-  KF5::KIOWidgets
-  KF5::KIONTLM
-  Qt5::PrintSupport
-  Poppler::Qt5
+target_link_libraries(
+    ktikzpart
+    KF5::Parts
+    KF5::IconThemes
+    KF5::CoreAddons
+    KF5::KIOCore
+    KF5::KIOFileWidgets
+    KF5::KIOWidgets
+    KF5::KIONTLM
+    Qt5::PrintSupport
+    Poppler::Qt5
 )
-
 
 install(TARGETS ktikzpart DESTINATION ${KDE_INSTALL_PLUGINDIR})
 install(FILES ktikzpart.rc DESTINATION ${KTIKZPART_DATA_INSTALL_DIR})
 install(FILES ktikzpart.desktop DESTINATION ${KDE_INSTALL_KSERVICES5DIR})
 
 add_custom_target(uninstalldirs_part)
-add_custom_command(TARGET uninstalldirs_part
-	POST_BUILD
-	COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZPART_DATA_INSTALL_DIR}
-	COMMENT "Removing directory ${KTIKZPART_DATA_INSTALL_DIR}"
-	VERBATIM)
+add_custom_command(
+    TARGET uninstalldirs_part
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${KTIKZPART_DATA_INSTALL_DIR}
+    COMMENT "Removing directory ${KTIKZPART_DATA_INSTALL_DIR}"
+    VERBATIM
+)

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -1,29 +1,23 @@
 include(../KtikzConfig.cmake)
 
 ### Install qm files
-
 file(GLOB ktikz_TS_FILES */qtikz_*.ts)
 qt5_add_translation(ktikz_QM_FILES ${ktikz_TS_FILES})
 add_custom_target(translations ALL DEPENDS ${ktikz_QM_FILES})
 install(FILES ${ktikz_QM_FILES} DESTINATION ${KTIKZ_TRANSLATIONS_INSTALL_DIR})
 
 ### Install po files
-
 find_package(Gettext)
 if(GETTEXT_FOUND)
-	add_subdirectory(cs)
-	add_subdirectory(de)
-	add_subdirectory(es)
-	add_subdirectory(fr)
+    add_subdirectory(cs)
+    add_subdirectory(de)
+    add_subdirectory(es)
+    add_subdirectory(fr)
 else(GETTEXT_FOUND)
-	message(
-"------
-                 NOTE: Gettext not found. Translations will *not* be installed.
-------")
+    message("NOTE: Gettext not found. Translations will *not* be installed.")
 endif(GETTEXT_FOUND)
 
 ### Generate ts files (only to be used when ../app/tikzcommands.xml has changed)
-
 set(TIKZCOMMANDS_TR_H tikzcommands_tr.h)
 set(XMLPATTERNS xmlpatterns)
 set(LUPDATE lupdate)
@@ -31,14 +25,23 @@ set(LUPDATE lupdate)
 add_custom_target(ts)
 find_program(SED_EXE NAMES sed)
 if(SED_EXE)
-	add_custom_command(TARGET ts
-		COMMAND ${XMLPATTERNS} -output ${TIKZCOMMANDS_TR_H}_tmp ${CMAKE_CURRENT_SOURCE_DIR}/../app/extract-tikzcommands.xq
-		COMMAND ${SED_EXE} -e "s/amp\\;//g" ${TIKZCOMMANDS_TR_H}_tmp > ${TIKZCOMMANDS_TR_H}
-		COMMAND ${LUPDATE} ${CMAKE_CURRENT_SOURCE_DIR}/../app ${CMAKE_CURRENT_SOURCE_DIR}/../common ${CMAKE_CURRENT_SOURCE_DIR}/../common/utils ${CMAKE_CURRENT_BINARY_DIR}/${TIKZCOMMANDS_TR_H} -ts ${ktikz_TS_FILES}
-		COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/${TIKZCOMMANDS_TR_H}_tmp
-		COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/${TIKZCOMMANDS_TR_H}
-		VERBATIM
-	)
+    add_custom_command(
+        TARGET ts
+        COMMAND
+            ${XMLPATTERNS} -output ${TIKZCOMMANDS_TR_H}_tmp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../app/extract-tikzcommands.xq
+        COMMAND ${SED_EXE} -e "s/amp\\;//g" ${TIKZCOMMANDS_TR_H}_tmp > ${TIKZCOMMANDS_TR_H}
+        COMMAND
+            ${LUPDATE} ${CMAKE_CURRENT_SOURCE_DIR}/../app ${CMAKE_CURRENT_SOURCE_DIR}/../common
+            ${CMAKE_CURRENT_SOURCE_DIR}/../common/utils
+            ${CMAKE_CURRENT_BINARY_DIR}/${TIKZCOMMANDS_TR_H} -ts ${ktikz_TS_FILES}
+        COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/${TIKZCOMMANDS_TR_H}_tmp
+        COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_CURRENT_BINARY_DIR}/${TIKZCOMMANDS_TR_H}
+        VERBATIM
+    )
 else(SED_EXE)
-	message(STATUS "Unable to find sed. Please install it if you want to use the \"make ts\" target.")
+    message(
+        STATUS
+        "Unable to find sed. Please install it if you want to use the \"make ts\" target."
+    )
 endif(SED_EXE)


### PR DESCRIPTION
This auto-formats the `CMakeLists.txt` files a bit using [gersemi](https://github.com/BlankSpruce/gersemi) (it's not great, but it seems to be maintained). The formatting tries to match the settings in `.clang-format`.

Applied using [fd](https://github.com/sharkdp/fd)
```
fd -e txt -x gersemi --line-length 100 --indent 4 -i CMakeLists.txt
```