### PR TITLE
Port to new style signal slot syntax

### DIFF
--- a/app/aboutdialog.cpp
+++ b/app/aboutdialog.cpp
@@ -59,7 +59,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
     textEdit->setReadOnly(true);
     textEdit->setOpenExternalLinks(true);
     QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &AboutDialog::accept);
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
     mainLayout->addWidget(topWidget);

--- a/app/configappearancewidget.cpp
+++ b/app/configappearancewidget.cpp
@@ -36,7 +36,8 @@ ConfigAppearanceWidget::ConfigAppearanceWidget(QWidget *parent) : QWidget(parent
     buttonGroup->addButton(ui.standardAppearanceCheck);
     buttonGroup->addButton(ui.customAppearanceCheck);
     buttonGroup->setExclusive(true);
-    connect(buttonGroup, SIGNAL(buttonClicked(QAbstractButton *)), this, SLOT(toggleCustom()));
+    connect(buttonGroup, QOverload<QAbstractButton *>::of(&QButtonGroup::buttonClicked), this,
+            [this](QAbstractButton *) { toggleCustom(); });
 
     QPalette palette = ui.itemTable->palette();
     QColor highlightBackgroundColor(QApplication::style()->standardPalette().color(
@@ -51,11 +52,13 @@ ConfigAppearanceWidget::ConfigAppearanceWidget(QWidget *parent) : QWidget(parent
     palette.setColor(QPalette::Disabled, QPalette::Highlight, highlightBackgroundColor);
     ui.itemTable->setPalette(palette);
     m_itemHighlighted = -1;
-    connect(ui.itemTable, SIGNAL(currentItemChanged(QTableWidgetItem *, QTableWidgetItem *)), this,
-            SLOT(setItemHighlighted(QTableWidgetItem *)));
+    connect(ui.itemTable, &QTableWidget::currentItemChanged, this,
+            &ConfigAppearanceWidget::setItemHighlighted);
 
-    connect(ui.fontButton, SIGNAL(clicked()), this, SLOT(showFontDialog()));
-    connect(ui.colorButton, SIGNAL(clicked()), this, SLOT(showColorDialog()));
+    connect(ui.fontButton, &QAbstractButton::clicked, this,
+            &ConfigAppearanceWidget::showFontDialog);
+    connect(ui.colorButton, &QAbstractButton::clicked, this,
+            &ConfigAppearanceWidget::showColorDialog);
 }
 
 void ConfigAppearanceWidget::readSettings(const QString &settingsGroup)

--- a/app/configeditorwidget.cpp
+++ b/app/configeditorwidget.cpp
@@ -31,7 +31,7 @@ ConfigEditorWidget::ConfigEditorWidget(QWidget *parent) : QWidget(parent)
 {
     ui.setupUi(this);
 
-    connect(ui.generalFontButton, SIGNAL(clicked()), this, SLOT(selectFont()));
+    connect(ui.generalFontButton, &QAbstractButton::clicked, this, &ConfigEditorWidget::selectFont);
 
     // ** Encoding
     initializeEncoding();

--- a/app/configgeneralwidget.cpp
+++ b/app/configgeneralwidget.cpp
@@ -55,11 +55,12 @@ ConfigGeneralWidget::ConfigGeneralWidget(QWidget *parent) : QWidget(parent)
     ui.pdftopsButton->setIcon(Icon(QLatin1String("document-open")));
     ui.editorButton->setIcon(Icon(QLatin1String("document-open")));
 
-    connect(ui.tikzDocButton, SIGNAL(clicked()), this, SLOT(browseCommand()));
-    connect(ui.tikzDocSearchButton, SIGNAL(clicked()), this, SLOT(searchTikzDocumentation()));
-    connect(ui.latexButton, SIGNAL(clicked()), this, SLOT(browseCommand()));
-    connect(ui.pdftopsButton, SIGNAL(clicked()), this, SLOT(browseCommand()));
-    connect(ui.editorButton, SIGNAL(clicked()), this, SLOT(browseCommand()));
+    connect(ui.tikzDocButton, &QAbstractButton::clicked, this, [this]() { browseCommand(); });
+    connect(ui.tikzDocSearchButton, &QAbstractButton::clicked, this,
+            &ConfigGeneralWidget::searchTikzDocumentation);
+    connect(ui.latexButton, &QAbstractButton::clicked, this, [this]() { browseCommand(); });
+    connect(ui.pdftopsButton, &QAbstractButton::clicked, this, [this]() { browseCommand(); });
+    connect(ui.editorButton, &QAbstractButton::clicked, this, [this]() { browseCommand(); });
 }
 
 ConfigGeneralWidget::~ConfigGeneralWidget()

--- a/app/editgotolinewidget.cpp
+++ b/app/editgotolinewidget.cpp
@@ -29,8 +29,8 @@ GoToLineWidget::GoToLineWidget(QWidget *parent) : QWidget(parent)
 
     setFocusProxy(ui.spinBoxGo);
 
-    connect(ui.pushButtonGo, SIGNAL(clicked()), this, SLOT(goToLine()));
-    connect(ui.pushButtonClose, SIGNAL(clicked()), this, SLOT(hide()));
+    connect(ui.pushButtonGo, &QAbstractButton::clicked, this, [this]() { goToLine(); });
+    connect(ui.pushButtonClose, &QAbstractButton::clicked, this, &GoToLineWidget::hide);
 }
 
 GoToLineWidget::~GoToLineWidget() { }

--- a/app/editindentwidget.cpp
+++ b/app/editindentwidget.cpp
@@ -30,8 +30,8 @@ IndentWidget::IndentWidget(QWidget *parent) : QWidget(parent)
 
     readSettings();
 
-    connect(ui.pushButtonIndent, SIGNAL(clicked()), this, SLOT(indent()));
-    connect(ui.pushButtonClose, SIGNAL(clicked()), this, SLOT(hide()));
+    connect(ui.pushButtonIndent, &QAbstractButton::clicked, this, [this]() { indent(); });
+    connect(ui.pushButtonClose, &QAbstractButton::clicked, this, &IndentWidget::hide);
 }
 
 IndentWidget::~IndentWidget() { }

--- a/app/editreplacecurrentwidget.cpp
+++ b/app/editreplacecurrentwidget.cpp
@@ -50,10 +50,10 @@ ReplaceCurrentWidget::ReplaceCurrentWidget(QWidget *parent) : QWidget(parent)
 
     setFocusProxy(m_replaceButton);
 
-    connect(m_replaceButton, SIGNAL(clicked()), this, SIGNAL(replace()));
-    connect(replaceAllButton, SIGNAL(clicked()), this, SIGNAL(replaceAll()));
-    connect(dontReplaceButton, SIGNAL(clicked()), this, SLOT(dontReplace()));
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(hide()));
+    connect(m_replaceButton, &QAbstractButton::clicked, this, &ReplaceCurrentWidget::replace);
+    connect(replaceAllButton, &QAbstractButton::clicked, this, &ReplaceCurrentWidget::replaceAll);
+    connect(dontReplaceButton, &QAbstractButton::clicked, this, &ReplaceCurrentWidget::dontReplace);
+    connect(cancelButton, &QAbstractButton::clicked, this, &ReplaceCurrentWidget::hide);
 }
 
 ReplaceCurrentWidget::~ReplaceCurrentWidget() { }

--- a/app/editreplacewidget.cpp
+++ b/app/editreplacewidget.cpp
@@ -41,18 +41,20 @@ ReplaceWidget::ReplaceWidget(QWidget *parent) : QWidget(parent)
 #ifdef KTIKZ_USE_KDE
     // activate completion
     KCompletion *completion = ui.comboBoxFind->completionObject();
-    connect(ui.comboBoxFind, SIGNAL(returnPressed(QString)), completion, SLOT(addItem(QString)));
+    connect(ui.comboBoxFind, QOverload<const QString &>::of(&KComboBox::returnPressed), completion,
+            [completion](const QString &text) { completion->addItem(text); });
     completion = ui.comboBoxReplace->completionObject();
-    connect(ui.comboBoxReplace, SIGNAL(returnPressed(QString)), completion, SLOT(addItem(QString)));
+    connect(ui.comboBoxReplace, QOverload<const QString &>::of(&KComboBox::returnPressed),
+            completion, [completion](const QString &text) { completion->addItem(text); });
 #endif
 
     setFocusProxy(ui.comboBoxFind);
 
-    connect(ui.pushButtonBackward, SIGNAL(clicked()), this, SLOT(setBackward()));
-    connect(ui.pushButtonForward, SIGNAL(clicked()), this, SLOT(setForward()));
-    connect(ui.pushButtonFind, SIGNAL(clicked()), this, SLOT(doFind()));
-    connect(ui.pushButtonReplace, SIGNAL(clicked()), this, SLOT(doReplace()));
-    connect(ui.pushButtonClose, SIGNAL(clicked()), this, SLOT(hide()));
+    connect(ui.pushButtonBackward, &QAbstractButton::clicked, this, &ReplaceWidget::setBackward);
+    connect(ui.pushButtonForward, &QAbstractButton::clicked, this, [this]() { setForward(); });
+    connect(ui.pushButtonFind, &QAbstractButton::clicked, this, &ReplaceWidget::doFind);
+    connect(ui.pushButtonReplace, &QAbstractButton::clicked, this, &ReplaceWidget::doReplace);
+    connect(ui.pushButtonClose, &QAbstractButton::clicked, this, &ReplaceWidget::hide);
 }
 
 ReplaceWidget::~ReplaceWidget() { }

--- a/app/tikzcommandinserter.cpp
+++ b/app/tikzcommandinserter.cpp
@@ -413,8 +413,9 @@ QMenu *TikzCommandInserter::getMenu(const TikzCommandList &commandList, QWidget 
                     commandList.commands.at(i)
                             .number); // link to the corresponding item in m_tikzCommandsList
             action->setStatusTip(commandList.commands.at(i).description);
-            connect(action, SIGNAL(triggered()), this, SLOT(insertTag()));
-            connect(action, SIGNAL(hovered()), this, SLOT(updateDescriptionToolTip()));
+            connect(action, &QAction::triggered, this, [this]() { insertTag(); });
+            connect(action, &QAction::hovered, this,
+                    &TikzCommandInserter::updateDescriptionToolTip);
         }
     }
 
@@ -511,14 +512,12 @@ void TikzCommandInserter::showItemsInDockWidget()
         QListWidget *tikzListWidget = new QListWidget;
         addListWidgetItems(tikzListWidget, standardPalette, m_tikzSections.children.at(i));
         tikzListWidget->setMouseTracking(true);
-        connect(tikzListWidget, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)),
-                this, SLOT(setListStatusTip(QListWidgetItem *)));
-        connect(tikzListWidget, SIGNAL(itemEntered(QListWidgetItem *)), this,
-                SLOT(setListStatusTip(QListWidgetItem *)));
-        connect(tikzListWidget, SIGNAL(itemActivated(QListWidgetItem *)), this,
-                SLOT(insertTag(QListWidgetItem *)));
-        //		connect(tikzListWidget, SIGNAL(itemClicked(QListWidgetItem*)), this,
-        // SLOT(insertTag(QListWidgetItem*)));
+        connect(tikzListWidget, &QListWidget::currentItemChanged, this,
+                &TikzCommandInserter::setListStatusTip);
+        connect(tikzListWidget, &QListWidget::itemEntered, this,
+                &TikzCommandInserter::setListStatusTip);
+        connect(tikzListWidget, &QListWidget::itemActivated, this,
+                [this](QListWidgetItem *tag) { insertTag(tag); });
 
         QString comboItemText = m_tikzSections.children.at(i).title;
         m_commandsCombo->addItem(comboItemText.remove(QLatin1Char('&')));
@@ -549,25 +548,25 @@ QDockWidget *TikzCommandInserter::getDockWidget(QWidget *parent)
     QAction *focusTikzDockAction = new QAction(parent);
     focusTikzDockAction->setShortcut(QKeySequence(tr("Alt+I")));
     tikzDock->addAction(focusTikzDockAction);
-    connect(focusTikzDockAction, SIGNAL(triggered()), tikzDock, SLOT(setFocus()));
+    connect(focusTikzDockAction, &QAction::triggered, tikzDock,
+            [tikzDock]() { tikzDock->setFocus(); });
 
     QLabel *commandsComboLabel = new QLabel(tr("Category:"));
     m_commandsCombo = new ComboBox;
     m_commandsCombo->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     m_commandsStack = new QStackedWidget;
-    connect(m_commandsCombo, SIGNAL(currentIndexChanged(int)), m_commandsStack,
-            SLOT(setCurrentIndex(int)));
+    connect(m_commandsCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), m_commandsStack,
+            &QStackedWidget::setCurrentIndex);
 
     QListWidget *tikzListWidget = new QListWidget;
     tikzListWidget->setMouseTracking(true);
-    connect(tikzListWidget, SIGNAL(currentItemChanged(QListWidgetItem *, QListWidgetItem *)), this,
-            SLOT(setListStatusTip(QListWidgetItem *)));
-    connect(tikzListWidget, SIGNAL(itemEntered(QListWidgetItem *)), this,
-            SLOT(setListStatusTip(QListWidgetItem *)));
-    connect(tikzListWidget, SIGNAL(itemActivated(QListWidgetItem *)), this,
-            SLOT(insertTag(QListWidgetItem *)));
-    //	connect(tikzListWidget, SIGNAL(itemClicked(QListWidgetItem*)), this,
-    // SLOT(insertTag(QListWidgetItem*)));
+    connect(tikzListWidget, &QListWidget::currentItemChanged, this,
+            &TikzCommandInserter::setListStatusTip);
+    connect(tikzListWidget, &QListWidget::itemEntered, this,
+            &TikzCommandInserter::setListStatusTip);
+    connect(tikzListWidget, &QListWidget::itemActivated, this,
+            [this](QListWidgetItem *tag) { insertTag(tag); });
+
     m_commandsCombo->addItem(tr("General"));
     m_commandsStack->addWidget(tikzListWidget);
 

--- a/app/tikzeditor.cpp
+++ b/app/tikzeditor.cpp
@@ -70,16 +70,15 @@ TikzEditor::TikzEditor(QWidget *parent)
     m_lineNumberArea = new LineNumberWidget(this);
     updateLineNumberAreaWidth();
 
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
+    connect(this, &TikzEditor::cursorPositionChanged, this, &TikzEditor::highlightCurrentLine);
     highlightCurrentLine();
 
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(showCursorPosition()));
-    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(matchBrackets()));
-    connect(document(), SIGNAL(contentsChange(int, int, int)), this,
-            SLOT(recalculateBookmarks(int)));
+    connect(this, &TikzEditor::cursorPositionChanged, this, &TikzEditor::showCursorPosition);
+    connect(this, &TikzEditor::cursorPositionChanged, this, &TikzEditor::matchBrackets);
+    connect(document(), &QTextDocument::contentsChange, this, &TikzEditor::recalculateBookmarks);
 
-    connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth()));
-    connect(this, SIGNAL(updateRequest(QRect, int)), this, SLOT(updateLineNumberArea(QRect, int)));
+    connect(this, &TikzEditor::blockCountChanged, this, &TikzEditor::updateLineNumberAreaWidth);
+    connect(this, &TikzEditor::updateRequest, this, &TikzEditor::updateLineNumberArea);
 }
 
 TikzEditor::~TikzEditor() { }
@@ -598,7 +597,8 @@ void TikzEditor::updateCompleter(bool useCompletion, const QStringList &words)
         m_completer->setCompletionMode(QCompleter::PopupCompletion);
         m_completer->setCaseSensitivity(Qt::CaseInsensitive);
         m_completer->setWrapAround(false);
-        connect(m_completer, SIGNAL(activated(QString)), this, SLOT(insertCompletion(QString)));
+        connect(m_completer, QOverload<const QString &>::of(&QCompleter::activated), this,
+                &TikzEditor::insertCompletion);
     }
 
     QStringListModel *model = new QStringListModel(words, m_completer);

--- a/app/tikzktexteditorview.cpp
+++ b/app/tikzktexteditorview.cpp
@@ -42,17 +42,17 @@ TikzKTextEditorView::TikzKTextEditorView(QWidget *parent) : TikzEditorViewAbstra
 
     m_currentDoc->setMode(QStringLiteral("LaTeX"));
 
-    connect(m_currentDoc, SIGNAL(modifiedChanged(KTextEditor::Document *)), this,
-            SLOT(setDocumentModified(KTextEditor::Document *)));
+    connect(m_currentDoc, &KTextEditor::Document::modifiedChanged, this,
+            &TikzKTextEditorView::setDocumentModified);
 
-    connect(m_documentView, SIGNAL(focusIn(KTextEditor::View *)), this, SIGNAL(focusIn()));
-    connect(m_documentView, SIGNAL(focusOut(KTextEditor::View *)), this, SIGNAL(focusOut()));
+    connect(m_documentView, &KTextEditor::View::focusIn, this, &TikzKTextEditorView::focusIn);
+    connect(m_documentView, &KTextEditor::View::focusOut, this, &TikzKTextEditorView::focusOut);
 
-    connect(m_currentDoc, SIGNAL(textChanged(KTextEditor::Document *)), this,
-            SIGNAL(contentsChanged()));
+    connect(m_currentDoc, &KTextEditor::Document::textChanged, this,
+            &TikzKTextEditorView::contentsChanged);
 
-    connect(m_currentDoc, SIGNAL(urlChanged(const QUrl &)), this,
-            SIGNAL(documentUrlChanged(const QUrl &)));
+    connect(m_currentDoc, &KTextEditor::Document::urlChanged, this,
+            &TikzKTextEditorView::documentUrlChanged);
 
     KTextEditor::CodeCompletionInterface *cci =
             qobject_cast<KTextEditor::CodeCompletionInterface *>(m_documentView);

--- a/app/usercommandeditdialog.cpp
+++ b/app/usercommandeditdialog.cpp
@@ -29,18 +29,21 @@ UserCommandEditDialog::UserCommandEditDialog(QWidget *parent) : QDialog(parent),
 
     ui.comboBoxItem->setMinimumContentsLength(QString(tr("Menu item 100")).length());
 
-    connect(ui.pushButtonAdd, SIGNAL(clicked()), this, SLOT(addItem()));
-    connect(ui.pushButtonRemove, SIGNAL(clicked()), this, SLOT(removeItem()));
-    connect(ui.comboBoxItem, SIGNAL(currentIndexChanged(int)), this, SLOT(changeItem(int)));
-    connect(ui.pushButtonInsertPlaceHolder, SIGNAL(clicked()), this, SLOT(insertPlaceHolder()));
-    connect(ui.buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
+    connect(ui.pushButtonAdd, &QPushButton::clicked, this, &UserCommandEditDialog::addItem);
+    connect(ui.pushButtonRemove, &QPushButton::clicked, this, &UserCommandEditDialog::removeItem);
+    connect(ui.comboBoxItem, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &UserCommandEditDialog::changeItem);
+    connect(ui.pushButtonInsertPlaceHolder, &QPushButton::clicked, this,
+            &UserCommandEditDialog::insertPlaceHolder);
+    connect(ui.buttonBox, &QDialogButtonBox::accepted, this, &UserCommandEditDialog::accept);
 
     readSettings();
 }
 
 void UserCommandEditDialog::readSettings()
 {
-    disconnect(ui.comboBoxItem, SIGNAL(currentIndexChanged(int)), this, SLOT(changeItem(int)));
+    disconnect(ui.comboBoxItem, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+               &UserCommandEditDialog::changeItem);
     QSettings settings;
     int size = settings.beginReadArray(QLatin1String("UserCommands"));
     ui.comboBoxItem->clear();
@@ -52,7 +55,8 @@ void UserCommandEditDialog::readSettings()
         ui.comboBoxItem->insertItem(i, QString(tr("Menu item %1").arg(QString::number(i + 1))));
     }
     settings.endArray();
-    connect(ui.comboBoxItem, SIGNAL(currentIndexChanged(int)), this, SLOT(changeItem(int)));
+    connect(ui.comboBoxItem, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &UserCommandEditDialog::changeItem);
 
     if (m_names.size() > 0) {
         setEditingEnabled(true);
@@ -116,7 +120,8 @@ void UserCommandEditDialog::addItem()
 
 void UserCommandEditDialog::removeItem()
 {
-    disconnect(ui.comboBoxItem, SIGNAL(currentIndexChanged(int)), this, SLOT(changeItem(int)));
+    disconnect(ui.comboBoxItem, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+               &UserCommandEditDialog::changeItem);
 
     int index = ui.comboBoxItem->currentIndex();
     m_names.removeAt(index);
@@ -133,7 +138,8 @@ void UserCommandEditDialog::removeItem()
     if (index < 0)
         setEditingEnabled(false);
 
-    connect(ui.comboBoxItem, SIGNAL(currentIndexChanged(int)), this, SLOT(changeItem(int)));
+    connect(ui.comboBoxItem, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &UserCommandEditDialog::changeItem);
 }
 
 void UserCommandEditDialog::changeItem(int index)

--- a/app/usercommandinserter.cpp
+++ b/app/usercommandinserter.cpp
@@ -64,13 +64,13 @@ void UserCommandInserter::updateMenu()
     for (int i = 0; i < m_names.size(); ++i) {
         QAction *action = m_userMenu->addAction(m_names.at(i));
         action->setData(i);
-        connect(action, SIGNAL(triggered()), this, SLOT(insertTag()));
+        connect(action, &QAction::triggered, this, [this]() { insertTag(); });
     }
 
     m_userMenu->addSeparator();
 
     QAction *action = m_userMenu->addAction(tr("&Edit user commands"));
-    connect(action, SIGNAL(triggered()), this, SLOT(editCommands()));
+    connect(action, &QAction::triggered, this, &UserCommandInserter::editCommands);
 }
 
 /*

--- a/common/templatewidget.cpp
+++ b/common/templatewidget.cpp
@@ -28,6 +28,7 @@
 #include <QtGui/QTextDocument>
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QLineEdit>
+#include <QtWidgets/QPushButton>
 
 #include "utils/combobox.h"
 #include "utils/filedialog.h"
@@ -53,11 +54,13 @@ TemplateWidget::TemplateWidget(QWidget *parent) : QWidget(parent)
     m_urlCompletion = new UrlCompletion(this);
     ui.templateCombo->setCompletionObject(m_urlCompletion);
 
-    connect(ui.templateChooseButton, SIGNAL(clicked()), this, SLOT(selectTemplateFile()));
-    connect(ui.templateEditButton, SIGNAL(clicked()), this, SLOT(editTemplateFile()));
-    connect(ui.templateReloadButton, SIGNAL(clicked()), this, SLOT(reloadTemplateFile()));
-    connect(ui.templateCombo->lineEdit(), SIGNAL(textChanged(QString)), this,
-            SIGNAL(fileNameChanged(QString)));
+    connect(ui.templateChooseButton, &QPushButton::clicked, this,
+            &TemplateWidget::selectTemplateFile);
+    connect(ui.templateEditButton, &QPushButton::clicked, this, &TemplateWidget::editTemplateFile);
+    connect(ui.templateReloadButton, &QPushButton::clicked, this,
+            &TemplateWidget::reloadTemplateFile);
+    connect(ui.templateCombo->lineEdit(), &QLineEdit::textChanged, this,
+            &TemplateWidget::fileNameChanged);
 
     readRecentTemplates();
 }
@@ -98,15 +101,15 @@ void TemplateWidget::saveRecentTemplates()
 
 void TemplateWidget::setFileName(const QString &fileName)
 {
-    disconnect(ui.templateCombo->lineEdit(), SIGNAL(textChanged(QString)), this,
-               SIGNAL(fileNameChanged(QString)));
+    disconnect(ui.templateCombo->lineEdit(), &QLineEdit::textChanged, this,
+               &TemplateWidget::fileNameChanged);
     const int index = ui.templateCombo->findText(fileName);
     if (index >= 0) // then remove item in order to re-add it at the top
         ui.templateCombo->removeItem(index);
     ui.templateCombo->insertItem(0, fileName);
     ui.templateCombo->lineEdit()->setText(QString());
-    connect(ui.templateCombo->lineEdit(), SIGNAL(textChanged(QString)), this,
-            SIGNAL(fileNameChanged(QString)));
+    connect(ui.templateCombo->lineEdit(), &QLineEdit::textChanged, this,
+            &TemplateWidget::fileNameChanged);
     ui.templateCombo->setCurrentIndex(0);
 }
 

--- a/common/tikzpreview.cpp
+++ b/common/tikzpreview.cpp
@@ -65,10 +65,10 @@ TikzPreview::TikzPreview(QWidget *parent)
     createActions();
 
     m_tikzPreviewRenderer = new TikzPreviewRenderer();
-    connect(this, SIGNAL(generatePreview(Poppler::Document *, qreal, int)), m_tikzPreviewRenderer,
-            SLOT(generatePreview(Poppler::Document *, qreal, int)));
-    connect(m_tikzPreviewRenderer, SIGNAL(showPreview(QImage, qreal)), this,
-            SLOT(showPreview(QImage, qreal)));
+    connect(this, &TikzPreview::generatePreview, m_tikzPreviewRenderer,
+            &TikzPreviewRenderer::generatePreview);
+    connect(m_tikzPreviewRenderer, &TikzPreviewRenderer::showPreview, this,
+            &TikzPreview::showPreview);
 }
 
 TikzPreview::~TikzPreview()
@@ -116,7 +116,7 @@ void TikzPreview::createActions()
     m_zoomToAction = new ZoomAction(Icon(QLatin1String("zoom-original")), tr("&Zoom"), this,
                                     QLatin1String("zoom_to"));
     m_zoomToAction->setZoomFactor(m_zoomFactor);
-    connect(m_zoomToAction, SIGNAL(zoomFactorAdded(qreal)), this, SLOT(setZoomFactor(qreal)));
+    connect(m_zoomToAction, &ZoomAction::zoomFactorAdded, this, &TikzPreview::setZoomFactor);
 
     m_previousPageAction = new Action(Icon(QLatin1String("go-previous")), tr("&Previous image"),
                                       this, QLatin1String("view_previous_image"));
@@ -124,7 +124,7 @@ void TikzPreview::createActions()
     m_previousPageAction->setStatusTip(tr("Show previous image in preview"));
     m_previousPageAction->setWhatsThis(
             tr("<p>Show the preview of the previous tikzpicture in the TikZ code.</p>"));
-    connect(m_previousPageAction, SIGNAL(triggered()), this, SLOT(showPreviousPage()));
+    connect(m_previousPageAction, &Action::triggered, this, &TikzPreview::showPreviousPage);
 
     m_nextPageAction = new Action(Icon(QLatin1String("go-next")), tr("&Next image"), this,
                                   QLatin1String("view_next_image"));
@@ -132,7 +132,7 @@ void TikzPreview::createActions()
     m_nextPageAction->setStatusTip(tr("Show next image in preview"));
     m_nextPageAction->setWhatsThis(
             tr("<p>Show the preview of the next tikzpicture in the TikZ code.</p>"));
-    connect(m_nextPageAction, SIGNAL(triggered()), this, SLOT(showNextPage()));
+    connect(m_nextPageAction, &Action::triggered, this, &TikzPreview::showNextPage);
 
     m_previousPageAction->setVisible(false);
     m_previousPageAction->setEnabled(false);

--- a/common/utils/colorbutton.cpp
+++ b/common/utils/colorbutton.cpp
@@ -30,13 +30,13 @@
 
 ColorButton::ColorButton(QWidget *parent) : QToolButton(parent)
 {
-    connect(this, SIGNAL(clicked()), this, SLOT(showColorDialog()));
+    connect(this, &ColorButton::clicked, this, &ColorButton::showColorDialog);
 }
 
 ColorButton::ColorButton(const QColor &color, QWidget *parent) : QToolButton(parent)
 {
     setColor(color);
-    connect(this, SIGNAL(clicked()), this, SLOT(showColorDialog()));
+    connect(this, &ColorButton::clicked, this, &ColorButton::showColorDialog);
 }
 
 void ColorButton::showColorDialog()

--- a/common/utils/lineedit.cpp
+++ b/common/utils/lineedit.cpp
@@ -47,8 +47,8 @@ void LineEdit::init()
     m_clearButton->setStyleSheet(QLatin1String("QToolButton { border: none; padding: 0px; }"));
     m_clearButton->setToolTip(tr("Clear input field"));
     m_clearButton->hide();
-    connect(m_clearButton, SIGNAL(clicked()), this, SLOT(clear()));
-    connect(this, SIGNAL(textChanged(QString)), this, SLOT(updateClearButton(QString)));
+    connect(m_clearButton, &QToolButton::clicked, this, &LineEdit::clear);
+    connect(this, &LineEdit::textChanged, this, &LineEdit::updateClearButton);
     //	const int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
     //	setStyleSheet(QString("QLineEdit { padding-right: %1px; width: %2px; height: %3px; }")
     //	              .arg(m_clearButton->sizeHint().width() + frameWidth + 1)

--- a/common/utils/pagedialog.cpp
+++ b/common/utils/pagedialog.cpp
@@ -28,8 +28,10 @@ PageDialog::PageDialog(QWidget *parent) : KPageDialog(parent)
     QPushButton *okButton = buttonBox()->button(QDialogButtonBox::Ok);
     okButton->setDefault(true);
     okButton->setShortcut(Qt::CTRL | Qt::Key_Return);
-    connect(buttonBox()->button(QDialogButtonBox::Apply), SIGNAL(clicked()), this, SLOT(accept()));
-    connect(okButton, SIGNAL(clicked()), this, SLOT(accept()));
+    connect(okButton, &QPushButton::clicked, this, &PageDialog::accept);
+
+    QPushButton *applyButton = buttonBox()->button(QDialogButtonBox::Apply);
+    connect(applyButton, &QPushButton::clicked, this, &PageDialog::accept);
 }
 
 void PageDialog::addPage(QWidget *widget, const QString &title, const QString &iconName)
@@ -73,8 +75,8 @@ PageDialog::PageDialog(QWidget *parent) : QDialog(parent)
     buttonBox->addButton(whatsThisButton, QDialogButtonBox::HelpRole);
     buttonBox->addButton(QDialogButtonBox::Ok);
     buttonBox->addButton(QDialogButtonBox::Cancel);
-    connect(buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &PageDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &PageDialog::reject);
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->addWidget(centerWidget());
@@ -104,9 +106,9 @@ QWidget *PageDialog::centerWidget()
 
     // add pages
     m_pagesStackedWidget = new QStackedWidget;
-    connect(m_pagesListWidget, SIGNAL(currentRowChanged(int)), m_pagesStackedWidget,
-            SLOT(setCurrentIndex(int)));
-    connect(m_pagesListWidget, SIGNAL(currentRowChanged(int)), this, SLOT(setCurrentPage(int)));
+    connect(m_pagesListWidget, &QListWidget::currentRowChanged, m_pagesStackedWidget,
+            &QStackedWidget::setCurrentIndex);
+    connect(m_pagesListWidget, &QListWidget::currentRowChanged, this, &PageDialog::setCurrentPage);
 
     QWidget *mainWidget = new QWidget;
     QGridLayout *mainLayout = new QGridLayout;

--- a/common/utils/printpreviewdialog.cpp
+++ b/common/utils/printpreviewdialog.cpp
@@ -35,32 +35,33 @@ PrintPreviewDialog::PrintPreviewDialog(QPrinter *printer, QWidget *parent) : QDi
     QVBoxLayout *mainLayout = new QVBoxLayout;
 
     m_printPreviewWidget = new QPrintPreviewWidget(printer, this);
-    connect(m_printPreviewWidget, SIGNAL(paintRequested(QPrinter *)), this,
-            SIGNAL(paintRequested(QPrinter *)));
-    connect(m_printPreviewWidget, SIGNAL(previewChanged()), this, SLOT(updateZoomFactor()));
+    connect(m_printPreviewWidget, &QPrintPreviewWidget::paintRequested, this,
+            &PrintPreviewDialog::paintRequested);
+    connect(m_printPreviewWidget, &QPrintPreviewWidget::previewChanged, this,
+            &PrintPreviewDialog::updateZoomFactor);
 
     ToolBar *toolBar = new ToolBar(QLatin1String("printpreview_toolbar"), this);
     Action *action = new Action(Icon(QLatin1String("zoom-fit-width")), tr("Fit &width"), this,
                                 QLatin1String("printpreview_fit_width"));
-    connect(action, SIGNAL(triggered()), m_printPreviewWidget, SLOT(fitToWidth()));
+    connect(action, &Action::triggered, m_printPreviewWidget, &QPrintPreviewWidget::fitToWidth);
     toolBar->addAction(action);
     action = new Action(Icon(QLatin1String("zoom-fit-best")), tr("Fit p&age"), this,
                         QLatin1String("printpreview_fit_page"));
-    connect(action, SIGNAL(triggered()), m_printPreviewWidget, SLOT(fitInView()));
+    connect(action, &Action::triggered, m_printPreviewWidget, &QPrintPreviewWidget::fitInView);
     toolBar->addAction(action);
     m_zoomToAction = new ZoomAction(Icon(QLatin1String("zoom-original")), tr("&Zoom"), this,
                                     QLatin1String("printpreview_zoom_to"));
-    connect(m_zoomToAction, SIGNAL(zoomFactorAdded(qreal)), this, SLOT(setZoomFactor(qreal)));
+    connect(m_zoomToAction, &ZoomAction::zoomFactorAdded, this, &PrintPreviewDialog::setZoomFactor);
     toolBar->addAction(m_zoomToAction);
     toolBar->addAction(StandardAction::zoomIn(this, SLOT(zoomIn()), this));
     toolBar->addAction(StandardAction::zoomOut(this, SLOT(zoomOut()), this));
     action = new Action(Icon(QLatin1String("document-print")), tr("&Print"), this,
                         QLatin1String("printpreview_print"));
-    connect(action, SIGNAL(triggered()), this, SLOT(print()));
+    connect(action, &Action::triggered, this, &PrintPreviewDialog::print);
     toolBar->addAction(action);
     action = new Action(Icon(QLatin1String("window-close")), tr("&Close"), this,
                         QLatin1String("printpreview_close"));
-    connect(action, SIGNAL(triggered()), this, SLOT(reject()));
+    connect(action, &Action::triggered, this, &PrintPreviewDialog::reject);
     toolBar->addAction(action);
 
     mainLayout->addWidget(toolBar);
@@ -87,9 +88,10 @@ void PrintPreviewDialog::setZoomFactor(qreal zoomFactor)
 
 void PrintPreviewDialog::updateZoomFactor()
 {
-    disconnect(m_zoomToAction, SIGNAL(zoomFactorAdded(qreal)), this, SLOT(setZoomFactor(qreal)));
+    disconnect(m_zoomToAction, &ZoomAction::zoomFactorAdded, this,
+               &PrintPreviewDialog::setZoomFactor);
     m_zoomToAction->setZoomFactor(m_printPreviewWidget->zoomFactor());
-    connect(m_zoomToAction, SIGNAL(zoomFactorAdded(qreal)), this, SLOT(setZoomFactor(qreal)));
+    connect(m_zoomToAction, &ZoomAction::zoomFactorAdded, this, &PrintPreviewDialog::setZoomFactor);
 }
 
 void PrintPreviewDialog::zoomIn()

--- a/common/utils/recentfilesaction.cpp
+++ b/common/utils/recentfilesaction.cpp
@@ -30,21 +30,18 @@
 RecentFilesAction::RecentFilesAction(QObject *parent) : KRecentFilesAction(parent)
 {
     Action::actionCollection()->addAction(QLatin1String("file_open_recent"), this);
-    // connect(this, SIGNAL(urlSelected(QUrl)), this, SLOT(selectUrl(QUrl)));
 }
 
 RecentFilesAction::RecentFilesAction(const QString &text, QObject *parent)
     : KRecentFilesAction(text, parent)
 {
     Action::actionCollection()->addAction(QLatin1String("file_open_recent"), this);
-    // connect(this, SIGNAL(urlSelected(QUrl)), this, SLOT(selectUrl(QUrl)));
 }
 
 RecentFilesAction::RecentFilesAction(const Icon &icon, const QString &text, QObject *parent)
     : KRecentFilesAction(icon, text, parent)
 {
     Action::actionCollection()->addAction(QLatin1String("file_open_recent"), this);
-    // connect(this, SIGNAL(urlSelected(QUrl)), this, SLOT(selectUrl(QUrl)));
 }
 
 void RecentFilesAction::loadEntries()
@@ -115,7 +112,7 @@ void RecentFilesAction::createRecentFilesList()
     for (int i = 0; i < m_numOfRecentFiles; ++i) {
         QAction *action = new QAction(this);
         action->setVisible(false);
-        connect(action, SIGNAL(triggered()), this, SLOT(openRecentFile()));
+        connect(action, &QAction::triggered, this, &RecentFilesAction::openRecentFile);
         m_recentFileActions.append(action);
     }
 

--- a/common/utils/selectaction.cpp
+++ b/common/utils/selectaction.cpp
@@ -77,7 +77,8 @@ void SelectAction::init(const QString &name)
 
     m_selectCombo = new QComboBox;
     setDefaultWidget(m_selectCombo);
-    connect(m_selectCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(setCurrentItem()));
+    connect(m_selectCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this](int index) { setCurrentItem(index); });
 }
 
 SelectAction::~SelectAction()
@@ -89,13 +90,14 @@ void SelectAction::setEditable(bool editable)
 {
     m_selectCombo->setEditable(editable);
     if (editable)
-        connect(m_selectCombo->lineEdit(), SIGNAL(returnPressed()), this, SLOT(setCurrentItem()));
+        connect(m_selectCombo->lineEdit(), &QLineEdit::returnPressed, this,
+                [this]() { setCurrentItem(); });
 }
 
 void SelectAction::setCurrentItem()
 {
     const QString text = m_selectCombo->currentText();
-    Q_EMIT triggered(text);
+    Q_EMIT textTriggered(text);
 }
 
 void SelectAction::removeAllActions()

--- a/common/utils/selectaction.h
+++ b/common/utils/selectaction.h
@@ -58,7 +58,7 @@ public:
     QStringList items() const;
 
 Q_SIGNALS:
-    void triggered(const QString &text);
+    void textTriggered(const QString &text);
 
 private Q_SLOTS:
     void setCurrentItem();

--- a/common/utils/zoomaction.cpp
+++ b/common/utils/zoomaction.cpp
@@ -49,7 +49,8 @@ void ZoomAction::init()
                     "Alternatively, you can also introduce a zoom factor and "
                     "press Enter.</p>"));
     setCurrentZoomFactor();
-    connect(this, SIGNAL(triggered(QString)), this, SLOT(setZoomFactor(QString)));
+    m_triggerConnection = connect(this, &ZoomAction::textTriggered, this,
+                                  [this](const QString &factor) { setZoomFactor(factor); });
 }
 
 ZoomAction::~ZoomAction() { }
@@ -106,12 +107,13 @@ void ZoomAction::setCurrentZoomFactor(qreal newZoomFactor)
         newZoomFactorPosition = zoomFactorNumber;
     }
 
-    disconnect(this, SIGNAL(triggered(QString)), this, SLOT(setZoomFactor(QString)));
+    disconnect(m_triggerConnection);
     removeAllActions();
     setItems(zoomFactorList);
     if (newZoomFactorPosition >= 0)
         setCurrentItem(newZoomFactorPosition);
-    connect(this, SIGNAL(triggered(QString)), this, SLOT(setZoomFactor(QString)));
+    m_triggerConnection = connect(this, &ZoomAction::textTriggered, this,
+                                  [this](const QString &factor) { setZoomFactor(factor); });
 }
 
 void ZoomAction::setZoomFactor(qreal zoomFactor)

--- a/common/utils/zoomaction.h
+++ b/common/utils/zoomaction.h
@@ -47,6 +47,8 @@ private Q_SLOTS:
 private:
     void init();
     void setCurrentZoomFactor(qreal newZoomFactor = 1);
+
+    QMetaObject::Connection m_triggerConnection;
 };
 
 #endif

--- a/part/configdialog.cpp
+++ b/part/configdialog.cpp
@@ -45,22 +45,23 @@ PartConfigDialog::PartConfigDialog(QWidget *parent) : QDialog(parent)
     QPushButton *okButton = m_buttonBox->button(QDialogButtonBox::Ok);
     okButton->setDefault(true);
     okButton->setShortcut(Qt::CTRL | Qt::Key_Return);
-    connect(m_buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-    connect(m_buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+    connect(m_buttonBox, &QDialogButtonBox::accepted, this, &PartConfigDialog::accept);
+    connect(m_buttonBox, &QDialogButtonBox::rejected, this, &PartConfigDialog::reject);
     // PORTING SCRIPT: WARNING mainLayout->addWidget(buttonBox) must be last item in layout. Please
     // move it.
     mainLayout->addWidget(m_buttonBox);
 
+    QPushButton *applyButton = m_buttonBox->button(QDialogButtonBox::Apply);
+    applyButton->setEnabled(false);
+
     setLayout(mainLayout);
 
-    connect(m_buttonBox->button(QDialogButtonBox::Apply), SIGNAL(clicked()), this,
-            SLOT(writeSettings()));
-    connect(okButton, SIGNAL(clicked()), this, SLOT(writeSettings()));
-    connect(m_buttonBox->button(QDialogButtonBox::RestoreDefaults), SIGNAL(clicked()), this,
-            SLOT(setDefaults()));
-    connect(m_configGeneralWidget, SIGNAL(changed(bool)), this,
-            SLOT(buttonBox->button(QDialogButtonBox::Apply)->setEnabled(bool)));
-    m_buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
+    connect(applyButton, &QPushButton::clicked, this, &PartConfigDialog::writeSettings);
+    connect(okButton, &QPushButton::clicked, this, &PartConfigDialog::writeSettings);
+    connect(m_buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this,
+            &PartConfigDialog::setDefaults);
+    connect(m_configGeneralWidget, &PartConfigGeneralWidget::changed, applyButton,
+            &QPushButton::setEnabled);
 }
 
 PartConfigDialog::~PartConfigDialog() { }
@@ -78,7 +79,7 @@ QWidget *PartConfigDialog::viewerWidget()
                   "by another program.</para>"));
     viewerLayout->addWidget(m_watchFileCheckBox);
 
-    connect(m_watchFileCheckBox, SIGNAL(toggled(bool)), this, SLOT(setModified()));
+    connect(m_watchFileCheckBox, &QCheckBox::toggled, this, &PartConfigDialog::setModified);
 
     return viewerGroupBox;
 }

--- a/part/configgeneralwidget.cpp
+++ b/part/configgeneralwidget.cpp
@@ -46,10 +46,13 @@ void PartConfigGeneralWidget::readSettings(const QString &settingsGroup)
     ui.replaceEdit->setText(settings.value("TemplateReplaceText", "<>").toString());
     settings.endGroup();
 
-    connect(ui.latexUrlRequester, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
-    connect(ui.pdftopsUrlRequester, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
-    connect(ui.editorUrlRequester, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
-    connect(ui.replaceEdit, SIGNAL(textChanged(QString)), this, SLOT(setModified()));
+    connect(ui.latexUrlRequester, &KUrlRequester::textChanged, this,
+            &PartConfigGeneralWidget::setModified);
+    connect(ui.pdftopsUrlRequester, &KUrlRequester::textChanged, this,
+            &PartConfigGeneralWidget::setModified);
+    connect(ui.editorUrlRequester, &KUrlRequester::textChanged, this,
+            &PartConfigGeneralWidget::setModified);
+    connect(ui.replaceEdit, &QLineEdit::textChanged, this, &PartConfigGeneralWidget::setModified);
 }
 
 void PartConfigGeneralWidget::setModified()

--- a/part/part.cpp
+++ b/part/part.cpp
@@ -93,10 +93,10 @@ Part::Part(QWidget *parentWidget, QObject *parent, const QVariantList &args)
 
     // document watcher and reloader
     m_watcher = new KDirWatch(this);
-    connect(m_watcher, SIGNAL(dirty(QString)), this, SLOT(slotFileDirty(QString)));
+    connect(m_watcher, &KDirWatch::dirty, this, &Part::slotFileDirty);
     m_dirtyHandler = new QTimer(this);
     m_dirtyHandler->setSingleShot(true);
-    connect(m_dirtyHandler, SIGNAL(timeout()), this, SLOT(slotDoFileDirty()));
+    connect(m_dirtyHandler, &QTimer::timeout, this, &Part::slotDoFileDirty);
 
     new BrowserExtension(
             this, m_tikzPreviewController); // needed to be able to use Konqueror's "Print" action
@@ -155,7 +155,7 @@ void Part::createActions()
     action = actionCollection()->addAction("help_about_ktikz");
     action->setText(i18n("About KtikZ Viewer"));
     action->setIcon(QIcon::fromTheme("ktikz"));
-    connect(action, SIGNAL(triggered()), this, SLOT(showAboutDialog()));
+    connect(action, &QAction::triggered, this, &Part::showAboutDialog);
 }
 
 /***************************************************************************/
@@ -209,7 +209,7 @@ void Part::saveAs()
         return;
 
     KIO::Job *job = KIO::file_copy(srcUrl, dstUrl, -1, KIO::Overwrite | KIO::HideProgressInfo);
-    connect(job, SIGNAL(result(KJob *)), this, SLOT(showJobError(KJob *)));
+    connect(job, &KIO::Job::result, this, &Part::showJobError);
 }
 
 bool Part::closeUrl()
@@ -312,7 +312,7 @@ void Part::configure()
 {
     if (m_configDialog == 0) {
         m_configDialog = new PartConfigDialog(widget());
-        connect(m_configDialog, SIGNAL(settingsChanged(QString)), this, SLOT(applySettings()));
+        connect(m_configDialog, &PartConfigDialog::settingsChanged, this, &Part::applySettings);
     }
     m_configDialog->readSettings();
     m_configDialog->show();


### PR DESCRIPTION
As described in https://wiki.qt.io/New_Signal_Slot_Syntax.

There are still a few places that use the old syntax that I was planning to leave for a future PR. They are:
1. `common/utils/standardaction.cpp`: This forwards some slots as a `const char *` and requires some more refactoring to make it work with the new style.
2. ~`common/utils/zoomaction.cpp`: There's a `disconnect` in there that isn't ported because I couldn't make it work when compiled with KF5. The signal is deprecated and it doesn't like something..~ Oops, this was just a misunderstanding on my side.. apparently `disconnect` doesn't work for lambas!
3. `app/mainwindow.cpp`: The new syntax is confused by `TikzEditorViewAbstract` not having a `contentsChanged` signal. This also seems like it requires some refactoring.

Otherwise, the porting is pretty straightforward. Some places are a bit less pretty because the new syntax requires explicit casting for overloaded functions, but it's not too bad.